### PR TITLE
Implement resizable layout with multiple charts

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,43 @@
+.container {
+  display: flex;
+  height: 100vh;
+}
+
+.leftPane {
+  overflow: auto;
+  padding: 20px;
+}
+
+.rightPane {
+  flex-grow: 1;
+  overflow: auto;
+  padding: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.resizer {
+  width: 5px;
+  cursor: col-resize;
+  background: #ddd;
+}
+
+.chart-box {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+  padding: 10px;
+  height: 100%;
+}
+
+.slider-label {
+  display: block;
+  font-size: 1.2em;
+  margin-bottom: 5px;
+}
+
+.slider-container {
+  margin-bottom: 20px;
+}


### PR DESCRIPTION
## Summary
- create resizable split layout via CSS and React state
- place sliders in the first pane with larger labels
- add radar, bar, pie and line charts in card-style boxes
- update charts automatically when parameters change
- style layout and boxes in new CSS file

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d8a9377c832fb936a0508c7a7dbf