### PR TITLE
Improve chart labels and fixed layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,43 @@
+.container {
+  display: flex;
+  height: 100vh;
+}
+
+.leftPane {
+  overflow: auto;
+  padding: 20px;
+}
+
+.rightPane {
+  flex-grow: 1;
+  overflow: auto;
+  padding: 20px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+}
+
+.resizer {
+  width: 5px;
+  cursor: col-resize;
+  background: #ddd;
+}
+
+.chart-box {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+  padding: 10px;
+  height: 100%;
+}
+
+.slider-label {
+  display: block;
+  font-size: 1.2em;
+  margin-bottom: 5px;
+}
+
+.slider-container {
+  margin-bottom: 20px;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,24 @@
-import React, { useState } from "react";
-import { Radar, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Tooltip, ResponsiveContainer } from "recharts";
+import React, { useState, useEffect } from "react";
+import {
+  Radar,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Tooltip,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  PieChart,
+  Pie,
+  Cell,
+  LineChart,
+  Line,
+  LabelList,
+} from "recharts";
+import "./App.css";
 
 export default function App() {
   const [params, setParams] = useState({
@@ -17,6 +36,26 @@ export default function App() {
     setParams({ ...params, [key]: value });
   };
 
+  const [leftWidth, setLeftWidth] = useState(30);
+  const [isResizing, setIsResizing] = useState(false);
+
+  const startResize = () => setIsResizing(true);
+
+  useEffect(() => {
+    const handleMove = (e) => {
+      if (!isResizing) return;
+      const newWidth = (e.clientX / window.innerWidth) * 100;
+      if (newWidth > 10 && newWidth < 80) setLeftWidth(newWidth);
+    };
+    const stopResize = () => setIsResizing(false);
+    document.addEventListener("mousemove", handleMove);
+    document.addEventListener("mouseup", stopResize);
+    return () => {
+      document.removeEventListener("mousemove", handleMove);
+      document.removeEventListener("mouseup", stopResize);
+    };
+  }, [isResizing]);
+
   const R1 = 1 - 0.3 * (params.v - params.v0);
   const R2 = 1 / (1 + (0.083 * Math.pow(params.v, 1.8)) / (params.j * Math.pow(params.L, 2 / 3)));
   const Q1_star = params.Q1 * R1;
@@ -32,34 +71,112 @@ export default function App() {
     { subject: "Formula Comb.", A: E_formula },
   ];
 
+  const barData = [
+    { name: "R1", value: R1 },
+    { name: "R2", value: R2 },
+  ];
+
+  const pieData = [
+    { name: "Q1*", value: Q1_star },
+    { name: "Q2*", value: Q2_star },
+  ];
+
+  const [lineData, setLineData] = useState([]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setLineData((d) => [
+        ...d.slice(-9),
+        { time: new Date().toLocaleTimeString().split(" ")[0], value: E },
+      ]);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [E]);
+
   return (
-    <div style={{ padding: 20 }}>
-      <h1>Efficienza Caditoie</h1>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 20 }}>
-        <div>
-          {Object.entries(params).map(([key, value]) => (
-            <div key={key} style={{ marginBottom: 10 }}>
-              <label>{key}: {value}</label>
-              <input
-                type="range"
-                min={key === "E0" ? 0 : 0.01}
-                max={key === "E0" ? 1 : key === "v" || key === "v0" ? 5 : 200}
-                step={key === "E0" || key === "j" || key === "L" ? 0.01 : 1}
-                value={value}
-                onChange={(e) => handleChange(key, e)}
-              />
-            </div>
-          ))}
-        </div>
-        <div style={{ width: 500, height: 400 }}>
-          <ResponsiveContainer width="100%" height="100%">
+    <div className="container">
+      <div className="leftPane" style={{ flexBasis: `${leftWidth}%` }}>
+        <h1>Efficienza Caditoie</h1>
+        {Object.entries(params).map(([key, value]) => (
+          <div key={key} className="slider-container">
+            <label className="slider-label">
+              {key}: {value.toFixed(2)}
+            </label>
+            <input
+              type="range"
+              min={key === "E0" ? 0 : 0.01}
+              max={key === "E0" ? 1 : key === "v" || key === "v0" ? 5 : 200}
+              step={key === "E0" || key === "j" || key === "L" ? 0.01 : 1}
+              value={value}
+              onChange={(e) => handleChange(key, e)}
+            />
+          </div>
+        ))}
+      </div>
+      <div className="resizer" onMouseDown={startResize} />
+      <div className="rightPane">
+        <div className="chart-box">
+          <ResponsiveContainer width="100%" height={300}>
             <RadarChart cx="50%" cy="50%" outerRadius="80%" data={data}>
               <PolarGrid />
               <PolarAngleAxis dataKey="subject" />
               <PolarRadiusAxis angle={30} domain={[0, 1]} />
-              <Radar name="Efficienze" dataKey="A" stroke="#8884d8" fill="#8884d8" fillOpacity={0.6} />
+              <Radar
+                name="Efficienze"
+                dataKey="A"
+                stroke="#8884d8"
+                fill="#8884d8"
+                fillOpacity={0.6}
+              >
+                <LabelList dataKey="A" formatter={(v) => v.toFixed(2)} />
+              </Radar>
               <Tooltip />
             </RadarChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div className="chart-box">
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={barData}>
+              <XAxis dataKey="name" />
+              <YAxis domain={[0, 1]} />
+              <Tooltip />
+              <Bar dataKey="value" fill="#82ca9d">
+                <LabelList dataKey="value" position="top" formatter={(v) => v.toFixed(2)} />
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div className="chart-box">
+          <ResponsiveContainer width="100%" height={300}>
+            <PieChart>
+              <Pie
+                data={pieData}
+                dataKey="value"
+                nameKey="name"
+                outerRadius={80}
+                label={({ name, value }) => `${name}: ${value.toFixed(2)}`}
+              >
+                {pieData.map((entry, index) => (
+                  <Cell key={`c-${index}`} fill={index ? "#8884d8" : "#82ca9d"} />
+                ))}
+              </Pie>
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div className="chart-box">
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={lineData}>
+              <XAxis dataKey="time" />
+              <YAxis domain={[0, 1]} />
+              <Tooltip />
+              <Line type="monotone" dataKey="value" stroke="#ff7300">
+                <LabelList dataKey="value" position="top" formatter={(v) => v.toFixed(2)} />
+              </Line>
+            </LineChart>
           </ResponsiveContainer>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix grid layout to show two charts per row
- display data labels for radar, bar, pie and line charts

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d8a9377c832fb936a0508c7a7dbf