### PR TITLE
Replace fourth chart with formulas

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -51,6 +51,10 @@
   height: 100%;
 }
 
+.formula-list p {
+  margin: 4px 0;
+}
+
 .slider-label {
   display: block;
   font-size: 1.2em;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -193,17 +193,15 @@ export default function App() {
         </div>
 
         <div className="chart-box">
-          <ResponsiveContainer width="100%" height={300}>
-            <LineChart data={lineData}>
-              <XAxis dataKey="time" />
-              <YAxis domain={[0, 1]} />
-              <Tooltip />
-              <Line type="monotone" dataKey="value" stroke="#ff7300">
-                <LabelList dataKey="value" position="top" formatter={(v) => v.toFixed(2)} />
-              </Line>
-
-            </LineChart>
-          </ResponsiveContainer>
+          <div className="formula-list">
+            <p>R1 = 1 - 0.3 (v - v0) = {R1.toFixed(2)}</p>
+            <p>R2 = 1 / (1 + (0.083 * v<sup>1.8</sup>) / (j * L<sup>2/3</sup>)) = {R2.toFixed(2)}</p>
+            <p>Q1* = Q1 × R1 = {Q1_star.toFixed(2)}</p>
+            <p>Q2 = Q - Q1 = {Q2.toFixed(2)}</p>
+            <p>Q2* = Q2 × R2 = {Q2_star.toFixed(2)}</p>
+            <p>E = (Q1* + Q2*) / Q = {E.toFixed(2)}</p>
+            <p>E formula = R1 × E0 + R2 × (1 - E0) = {E_formula.toFixed(2)}</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show formulas and calculated values in the fourth box instead of the line chart
- add basic styling for the formula list

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e882d25c832f833507d9ff5e0216