### PR TITLE
Add Jest test framework for efficiency calculations

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react']
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '\\.(css|less)$': 'identity-obj-proxy'
+  },
+  transform: {
+    '^.+\\.(js|jsx)$': 'babel-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -14,6 +15,13 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "jest": "^29.7.0",
+    "babel-jest": "^29.7.0",
+    "@babel/preset-env": "^7.22.20",
+    "@babel/preset-react": "^7.22.5",
+    "identity-obj-proxy": "^3.0.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import {
 
 } from "recharts";
 import "./App.css";
+import { calcR1, calcR2, calcTotalEfficiency } from "./utils/calc";
 
 export default function App() {
   const [params, setParams] = useState({
@@ -75,12 +76,12 @@ export default function App() {
     };
   }, [isResizing, isMobile]);
 
-  const R1 = 1 - 0.3 * (params.v - params.v0);
-  const R2 = 1 / (1 + (0.083 * Math.pow(params.v, 1.8)) / (params.j * Math.pow(params.L, 2 / 3)));
+  const R1 = calcR1(params.v, params.v0);
+  const R2 = calcR2(params.v, params.j, params.L);
   const Q1_star = params.Q1 * R1;
   const Q2 = params.Q - params.Q1;
   const Q2_star = Q2 * R2;
-  const E = (Q1_star + Q2_star) / params.Q;
+  const E = calcTotalEfficiency(params);
   const E_formula = R1 * params.E0 + R2 * (1 - params.E0);
 
   const data = [

--- a/src/__tests__/AppComponent.test.jsx
+++ b/src/__tests__/AppComponent.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import App from '../App';
+import '@testing-library/jest-dom';
+
+describe('App component calculations', () => {
+  test('shows calculated values for default parameters', () => {
+    render(<App />);
+    expect(screen.getByText(/R1 = 1 - 0.3 \(v - v0\) = 0.85/)).toBeInTheDocument();
+    expect(screen.getByText(/Q2\* = Q2 × R2 =/)).toBeInTheDocument();
+    expect(screen.getByText(/E = \(Q1\* \+ Q2\*\) \/ Q = 0.52/)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/calc.test.jsx
+++ b/src/__tests__/calc.test.jsx
@@ -1,0 +1,23 @@
+import { calcR1, calcR2, calcTotalEfficiency } from '../utils/calc';
+
+describe('calculation helpers', () => {
+  test('default parameter set', () => {
+    const params = { Q: 100, Q1: 60, v: 1.5, v0: 1.0, j: 0.01, L: 0.5 };
+    const r1 = calcR1(params.v, params.v0);
+    const r2 = calcR2(params.v, params.j, params.L);
+    const e = calcTotalEfficiency({ ...params, E0: 0.7 });
+    expect(r1).toBeCloseTo(0.85, 2);
+    expect(r2).toBeCloseTo(0.0353, 3);
+    expect(e).toBeCloseTo(0.5241, 3);
+  });
+
+  test('second parameter set', () => {
+    const params = { Q: 150, Q1: 30, v: 2, v0: 1, j: 0.02, L: 0.7 };
+    const r1 = calcR1(params.v, params.v0);
+    const r2 = calcR2(params.v, params.j, params.L);
+    const e = calcTotalEfficiency({ ...params, E0: 0.7 });
+    expect(r1).toBeCloseTo(0.7, 2);
+    expect(r2).toBeCloseTo(0.0517, 3);
+    expect(e).toBeCloseTo(0.1814, 3);
+  });
+});

--- a/src/utils/calc.js
+++ b/src/utils/calc.js
@@ -1,0 +1,16 @@
+export function calcR1(v, v0) {
+  return 1 - 0.3 * (v - v0);
+}
+
+export function calcR2(v, j, L) {
+  return 1 / (1 + (0.083 * Math.pow(v, 1.8)) / (j * Math.pow(L, 2 / 3)));
+}
+
+export function calcTotalEfficiency(params) {
+  const R1 = calcR1(params.v, params.v0);
+  const R2 = calcR2(params.v, params.j, params.L);
+  const Q1_star = params.Q1 * R1;
+  const Q2 = params.Q - params.Q1;
+  const Q2_star = Q2 * R2;
+  return (Q1_star + Q2_star) / params.Q;
+}


### PR DESCRIPTION
## Summary
- add Jest, RTL, and Babel configuration
- refactor calculations into `calc.js`
- use helper functions in `App`
- add unit tests for helper calculations and default component output

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f59dd244832f86f5534d5d10f91e