### PR TITLE
Add slider info popups

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -77,6 +77,39 @@
 
 .slider-container {
   margin-bottom: 20px;
+  position: relative;
+}
+
+.info-icon {
+  display: inline-block;
+  margin-left: 6px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #007bff;
+  color: #fff;
+  font-size: 12px;
+  line-height: 16px;
+  text-align: center;
+  cursor: pointer;
+}
+
+.info-popup {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 5px;
+  width: 200px;
+  z-index: 10;
+}
+
+.dark-mode .info-popup {
+  background: #1e1e1e;
+  color: #f5f5f5;
+  border-color: #555;
 }
 
 /* Dark mode styles */

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,16 @@ import "./App.css";
 import { calcR1, calcR2, calcTotalEfficiency } from "./utils/calc";
 import Help from "./Help";
 
+const paramInfo = {
+  Q: "Portata totale del deflusso (l/s).",
+  Q1: "Porzione di Q che raggiunge direttamente la caditoia (l/s).",
+  v: "Velocità del flusso all'ingresso (m/s).",
+  v0: "Velocità di riferimento per il calcolo di R1 (m/s).",
+  j: "Pendenza longitudinale della strada.",
+  L: "Lunghezza della griglia di caduta (m).",
+  E0: "Efficienza geometrica della caditoia.",
+};
+
 export default function App() {
   const [params, setParams] = useState({
     Q: 100,
@@ -47,6 +57,7 @@ export default function App() {
     return saved ? JSON.parse(saved) : false;
   });
   const [showHelp, setShowHelp] = useState(false);
+  const [infoParam, setInfoParam] = useState(null);
 
   useEffect(() => {
     localStorage.setItem("darkMode", JSON.stringify(isDarkMode));
@@ -55,6 +66,9 @@ export default function App() {
   const toggleDarkMode = () => setIsDarkMode((d) => !d);
 
   const startResize = () => setIsResizing(true);
+
+  const toggleInfo = (key) =>
+    setInfoParam((current) => (current === key ? null : key));
 
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth <= 768);
@@ -133,6 +147,12 @@ export default function App() {
               <div key={key} className="slider-container">
                 <label className="slider-label">
                   {key}: {value.toFixed(2)}
+                  <span className="info-icon" onClick={() => toggleInfo(key)}>
+                    i
+                  </span>
+                  {infoParam === key && (
+                    <div className="info-popup">{paramInfo[key]}</div>
+                  )}
                 </label>
                 <input
                   type="range"


### PR DESCRIPTION
## Summary
- add descriptions for each parameter
- create info icon next to sliders
- show popup with parameter explanation when icon is clicked
- style the icons and popup box

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b0577a44832f9d337122aa511d5b