### PR TITLE
Add line chart

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -122,6 +122,7 @@ export default function App() {
     radar: true,
     bar: true,
     pie: true,
+    line: true,
   });
 
   const toggleChart = (chart) =>
@@ -197,6 +198,14 @@ export default function App() {
                   onChange={() => toggleChart("pie")}
                 />
                 Grafico a torta
+              </label>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={visibleCharts.line}
+                  onChange={() => toggleChart("line")}
+                />
+                Grafico a linee
               </label>
             </div>
           </>
@@ -284,6 +293,20 @@ export default function App() {
                   </Pie>
                   <Tooltip />
                 </PieChart>
+              </ResponsiveContainer>
+            </div>
+            )}
+
+            {visibleCharts.line && (
+            <div className="chart-box">
+              <h3>Andamento efficienza</h3>
+              <ResponsiveContainer width="100%" height={300}>
+                <LineChart data={lineData}>
+                  <XAxis dataKey="time" />
+                  <YAxis domain={[0, 1]} />
+                  <Tooltip />
+                  <Line type="monotone" dataKey="value" stroke="#8884d8" />
+                </LineChart>
               </ResponsiveContainer>
             </div>
             )}

--- a/src/__tests__/AppComponent.test.jsx
+++ b/src/__tests__/AppComponent.test.jsx
@@ -9,4 +9,9 @@ describe('App component calculations', () => {
     expect(screen.getByText(/Q2\* = Q2 × R2 =/)).toBeInTheDocument();
     expect(screen.getByText(/E = \(Q1\* \+ Q2\*\) \/ Q = 0.52/)).toBeInTheDocument();
   });
+
+  test('shows line chart toggle', () => {
+    render(<App />);
+    expect(screen.getByLabelText('Grafico a linee')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- display line chart toggle and chart
- test that line toggle is shown

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b4c4eaf8832f810fac5dca6e1cea