### PR TITLE
Fix missing Legend import

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import {
   LineChart,
   Line,
   LabelList,
+  Legend,
 
 } from "recharts";
 import "./App.css";


### PR DESCRIPTION
## Summary
- import Legend component in App

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b9291cf8832f882c9eadac5e126c