### PR TITLE
Add efficiency evolution chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ Un file Excel di esempio è disponibile nella cartella `excel`.
 - Calcolo automatico di:
   - Efficienza R1
   - Efficienza R2
-  - Efficienza Totale
-  - Efficienza da formula combinata
+- Efficienza Totale
+- Efficienza da formula combinata
 
 - Visualizzazione su **grafico radar** dinamico.
+- Grafico evolutivo per Q o v su intervalli definiti.
 - Modalità chiaro/scuro con pulsante di attivazione.
 - Layout responsive con possibilità di ridimensionare i pannelli.
 

--- a/src/App.css
+++ b/src/App.css
@@ -165,6 +165,11 @@
   margin-bottom: 5px;
 }
 
+.range-selector label {
+  display: block;
+  margin-bottom: 5px;
+}
+
 .help-page {
   line-height: 1.6;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,7 @@ import {
 
 } from "recharts";
 import "./App.css";
-import { calcR1, calcR2, calcTotalEfficiency } from "./utils/calc";
+import { calcR1, calcR2, calcTotalEfficiency, generateEfficiencySeries } from "./utils/calc";
 import Help from "./Help";
 
 const paramInfo = {
@@ -59,6 +59,11 @@ export default function App() {
   });
   const [showHelp, setShowHelp] = useState(false);
   const [infoParam, setInfoParam] = useState(null);
+
+  const [rangeVar, setRangeVar] = useState("v");
+  const [rangeMin, setRangeMin] = useState(0.5);
+  const [rangeMax, setRangeMax] = useState(3);
+  const [evolutionData, setEvolutionData] = useState([]);
 
   useEffect(() => {
     localStorage.setItem("darkMode", JSON.stringify(isDarkMode));
@@ -124,6 +129,7 @@ export default function App() {
     bar: true,
     pie: true,
     line: true,
+    evolution: true,
   });
 
   const toggleChart = (chart) =>
@@ -137,6 +143,12 @@ export default function App() {
       { label: "E_formula", value: E_formula },
     ]);
   }, [E, R1, R2, E_formula]);
+
+  useEffect(() => {
+    setEvolutionData(
+      generateEfficiencySeries(params, rangeVar, rangeMin, rangeMax, 5)
+    );
+  }, [params, rangeVar, rangeMin, rangeMax]);
 
   return (
     <div className={`container ${isDarkMode ? "dark-mode" : ""}`}>
@@ -240,6 +252,43 @@ export default function App() {
                 />
                 Grafico a linee
               </label>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={visibleCharts.evolution}
+                  onChange={() => toggleChart("evolution")}
+                />
+                Grafico evolutivo
+              </label>
+            </div>
+
+            <div className="range-selector">
+              <label>
+                Variabile:
+                <select
+                  value={rangeVar}
+                  onChange={(e) => setRangeVar(e.target.value)}
+                >
+                  <option value="v">v</option>
+                  <option value="Q">Q</option>
+                </select>
+              </label>
+              <label>
+                Min:
+                <input
+                  type="number"
+                  value={rangeMin}
+                  onChange={(e) => setRangeMin(parseFloat(e.target.value))}
+                />
+              </label>
+              <label>
+                Max:
+                <input
+                  type="number"
+                  value={rangeMax}
+                  onChange={(e) => setRangeMax(parseFloat(e.target.value))}
+                />
+              </label>
             </div>
           </>
         )}
@@ -342,6 +391,22 @@ export default function App() {
                     <LabelList dataKey="value" position="top" formatter={(v) => v.toFixed(2)} />
                   </Line>
 
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+            )}
+
+            {visibleCharts.evolution && (
+            <div className="chart-box">
+              <h3>Grafico evolutivo ({rangeVar})</h3>
+              <ResponsiveContainer width="100%" height={300}>
+                <LineChart data={evolutionData}>
+                  <XAxis dataKey={rangeVar} />
+                  <YAxis domain={[0, 1]} />
+                  <Tooltip />
+                  <Line type="monotone" dataKey="efficiency" stroke="#ff7300">
+                    <LabelList dataKey="efficiency" position="top" formatter={(v) => v.toFixed(2)} />
+                  </Line>
                 </LineChart>
               </ResponsiveContainer>
             </div>

--- a/src/__tests__/calc.test.jsx
+++ b/src/__tests__/calc.test.jsx
@@ -1,4 +1,4 @@
-import { calcR1, calcR2, calcTotalEfficiency } from '../utils/calc';
+import { calcR1, calcR2, calcTotalEfficiency, generateEfficiencySeries } from '../utils/calc';
 
 describe('calculation helpers', () => {
   test('default parameter set', () => {
@@ -19,5 +19,25 @@ describe('calculation helpers', () => {
     expect(r1).toBeCloseTo(0.7, 2);
     expect(r2).toBeCloseTo(0.0517, 3);
     expect(e).toBeCloseTo(0.1814, 3);
+  });
+
+  test('generate series for varying v', () => {
+    const params = { Q: 100, Q1: 60, v: 1.5, v0: 1.0, j: 0.01, L: 0.5, E0: 0.7 };
+    const series = generateEfficiencySeries(params, 'v', 1, 2, 3);
+    expect(series).toHaveLength(3);
+    expect(series[0].v).toBeCloseTo(1);
+    expect(series[2].v).toBeCloseTo(2);
+    expect(series[1].efficiency).toBeCloseTo(
+      calcTotalEfficiency({ ...params, v: series[1].v }),
+      5
+    );
+  });
+
+  test('generate series for varying Q', () => {
+    const params = { Q: 100, Q1: 60, v: 1.5, v0: 1.0, j: 0.01, L: 0.5, E0: 0.7 };
+    const series = generateEfficiencySeries(params, 'Q', 50, 150, 5);
+    expect(series).toHaveLength(5);
+    expect(series[0].Q).toBeCloseTo(50);
+    expect(series[4].Q).toBeCloseTo(150);
   });
 });

--- a/src/utils/calc.js
+++ b/src/utils/calc.js
@@ -14,3 +14,15 @@ export function calcTotalEfficiency(params) {
   const Q2_star = Q2 * R2;
   return (Q1_star + Q2_star) / params.Q;
 }
+
+export function generateEfficiencySeries(params, variable, min, max, steps = 10) {
+  const results = [];
+  const count = Math.max(2, steps);
+  const delta = (max - min) / (count - 1);
+  for (let i = 0; i < count; i++) {
+    const value = min + delta * i;
+    const newParams = { ...params, [variable]: value };
+    results.push({ [variable]: value, efficiency: calcTotalEfficiency(newParams) });
+  }
+  return results;
+}


### PR DESCRIPTION
## Summary
- add `generateEfficiencySeries` utility for automatically building efficiency datasets over a range
- test generation of efficiency series for Q and v
- allow toggling new "Grafico evolutivo" in the UI and configure its range
- compute series with `generateEfficiencySeries` and show it in a new line chart
- document new feature

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c9e3bba4832fab890291888de2ec