### PR TITLE
Add parameter save/load

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Un file Excel di esempio è disponibile nella cartella `excel`.
 - Modalità chiaro/scuro con pulsante di attivazione.
 - Layout responsive con possibilità di ridimensionare i pannelli.
 - Esportazione dei dati e dei grafici in **CSV**, **Excel** e come immagini.
+- Salvataggio e caricamento dei parametri in locale o tramite file JSON.
 
 ## Avvio locale
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,7 +22,18 @@ import {
 } from "recharts";
 import "./App.css";
 import { validaParametri } from "./utils/validate";
-import { calcR1, calcR2, calcTotalEfficiency, generateEfficiencySeries } from "./utils/calc";
+import {
+  calcR1,
+  calcR2,
+  calcTotalEfficiency,
+  generateEfficiencySeries,
+} from "./utils/calc";
+import {
+  salvaParametri,
+  caricaParametri,
+  esportaParametri,
+  importaParametri,
+} from "./utils/storage";
 import Help from "./Help";
 
 const paramInfo = {
@@ -76,6 +87,7 @@ export default function App() {
   const pieRef = useRef(null);
   const lineRef = useRef(null);
   const evolutionRef = useRef(null);
+  const fileInputRef = useRef(null);
 
   useEffect(() => {
     localStorage.setItem("darkMode", JSON.stringify(isDarkMode));
@@ -200,6 +212,30 @@ export default function App() {
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+  };
+
+  const salvaParametriStorage = () => {
+    salvaParametri('savedParams', params);
+  };
+
+  const caricaParametriStorage = () => {
+    const loaded = caricaParametri('savedParams');
+    if (loaded) {
+      setParams(loaded);
+    }
+  };
+
+  const esportaJSON = () => {
+    esportaParametri(params);
+  };
+
+  const importaJSON = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      importaParametri(file)
+        .then((p) => setParams(p))
+        .catch(() => alert('File JSON non valido'));
+    }
   };
 
   const downloadImage = (ref, name) => {
@@ -368,6 +404,19 @@ export default function App() {
             <div className="export-buttons">
               <button onClick={downloadCSV}>Esporta CSV</button>
               <button onClick={downloadExcel}>Esporta Excel</button>
+              <button onClick={salvaParametriStorage}>Salva parametri</button>
+              <button onClick={caricaParametriStorage}>Carica parametri</button>
+              <button onClick={esportaJSON}>Esporta JSON</button>
+              <input
+                type="file"
+                accept="application/json"
+                ref={fileInputRef}
+                style={{ display: "none" }}
+                onChange={importaJSON}
+              />
+              <button onClick={() => fileInputRef.current.click()}>
+                Importa JSON
+              </button>
               <button onClick={() => downloadImage(radarRef, "radar.png")}>Salva radar</button>
               <button onClick={() => downloadImage(barRef, "barre.png")}>Salva barre</button>
               <button onClick={() => downloadImage(pieRef, "torta.png")}>Salva torta</button>

--- a/src/__tests__/AppComponent.test.jsx
+++ b/src/__tests__/AppComponent.test.jsx
@@ -28,6 +28,7 @@ describe('App component calculations', () => {
     render(<App />);
     expect(screen.getByText('Esporta CSV')).toBeInTheDocument();
     expect(screen.getByText('Esporta Excel')).toBeInTheDocument();
+    expect(screen.getByText('Salva parametri')).toBeInTheDocument();
   });
 
 });

--- a/src/__tests__/storage.test.js
+++ b/src/__tests__/storage.test.js
@@ -1,0 +1,10 @@
+import { salvaParametri, caricaParametri } from '../utils/storage';
+
+describe('salvaParametri e caricaParametri', () => {
+  test('salva e ricarica dallo storage', () => {
+    const params = { Q: 1 };
+    salvaParametri('test', params);
+    const loaded = caricaParametri('test');
+    expect(loaded).toEqual(params);
+  });
+});

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,44 @@
+export function salvaParametri(key, params) {
+  if (!key) return;
+  localStorage.setItem(key, JSON.stringify(params));
+}
+
+export function caricaParametri(key) {
+  if (!key) return null;
+  const data = localStorage.getItem(key);
+  if (!data) return null;
+  try {
+    return JSON.parse(data);
+  } catch (e) {
+    return null;
+  }
+}
+
+export function esportaParametri(params) {
+  const blob = new Blob([JSON.stringify(params, null, 2)], {
+    type: 'application/json',
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'parametri.json';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+export function importaParametri(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const params = JSON.parse(e.target.result);
+        resolve(params);
+      } catch (err) {
+        reject(err);
+      }
+    };
+    reader.onerror = () => reject(new Error('Errore lettura file'));
+    reader.readAsText(file);
+  });
+}


### PR DESCRIPTION
## Summary
- allow users to persist parameter sets
- handle JSON import/export and storage operations
- expose save/load buttons in UI
- test storage utilities and button visibility
- document new functionality in README

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853cf509224832f84637b6e22307524