### PR TITLE
Add help page and improve widgets

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,7 +21,7 @@
 .rightPane {
   flex-grow: 1;
   overflow: auto;
-  padding: 20px;
+  padding: 80px 20px 20px;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 20px;
@@ -58,6 +58,13 @@
 
 .dark-mode .sidebar-toggle {
   background: #0056b3;
+}
+
+.fixed-toggle {
+  position: fixed;
+  top: 60px;
+  left: 10px;
+  z-index: 1000;
 }
 
 .sidebar-header {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,6 +36,7 @@ import {
   importaParametri,
 } from "./utils/storage";
 import Widget from "./Widget";
+import Help from "./Help";
 
 const paramInfo = {
   Q: "Portata totale del deflusso (l/s).",
@@ -87,6 +88,7 @@ export default function App() {
   const pieRef = useRef(null);
   const lineRef = useRef(null);
   const evolutionRef = useRef(null);
+  const resultsRef = useRef(null);
   const fileInputRef = useRef(null);
 
   useEffect(() => {
@@ -140,8 +142,10 @@ export default function App() {
     pie: true,
     line: true,
     evolution: true,
+    results: true,
   });
   const [widgetOrder, setWidgetOrder] = useState([
+    'results',
     'radar',
     'bar',
     'pie',
@@ -149,7 +153,7 @@ export default function App() {
     'evolution',
   ]);
   const [dragging, setDragging] = useState(null);
-  const [appearanceOpen, setAppearanceOpen] = useState(true);
+  const [appearanceOpen, setAppearanceOpen] = useState(false);
 
   const toggleChart = (chart) =>
     setVisibleCharts((c) => ({ ...c, [chart]: !c[chart] }));
@@ -269,9 +273,31 @@ export default function App() {
       btoa(unescape(encodeURIComponent(svgString)));
   };
 
-  const [actionsOpen, setActionsOpen] = useState(true);
+  const [actionsOpen, setActionsOpen] = useState(false);
 
   const widgetMap = {
+    results: (
+      <Widget
+        id="results"
+        title="Risultati"
+        ref={resultsRef}
+        onDragStart={handleDragStart}
+        onDrop={handleDrop}
+      >
+        <div className="formula-list">
+          <p>R1 = 1 - 0.3 (v - v0) = {R1.toFixed(2)}</p>
+          <p>
+            R2 = 1 / (1 + (0.083 * v<sup>1.8</sup>) / (j * L<sup>2/3</sup>)) =
+            {R2.toFixed(2)}
+          </p>
+          <p>Q1* = Q1 × R1 = {Q1_star.toFixed(2)}</p>
+          <p>Q2 = Q - Q1 = {Q2.toFixed(2)}</p>
+          <p>Q2* = Q2 × R2 = {Q2_star.toFixed(2)}</p>
+          <p>E = (Q1* + Q2*) / Q = {E.toFixed(2)}</p>
+          <p>E formula = R1 × E0 + R2 × (1 - E0) = {E_formula.toFixed(2)}</p>
+        </div>
+      </Widget>
+    ),
     radar: (
       <Widget
         id="radar"
@@ -404,6 +430,14 @@ export default function App() {
           {isDarkMode ? '☀️' : '🌙'}
         </button>
       </header>
+      {!sidebarOpen && (
+        <button
+          className="sidebar-toggle fixed-toggle"
+          onClick={toggleSidebar}
+        >
+          ❯
+        </button>
+      )}
       <aside
         className={`leftPane bg-white shadow-md p-4 ${
           sidebarOpen ? "" : "collapsed"
@@ -423,6 +457,13 @@ export default function App() {
             }
           >
             {activePage === 'parameters' ? 'Simulazione' : 'Parametri'}
+          </button>
+
+          <button
+            className="px-4 py-2 text-left hover:bg-gray-100 w-full"
+            onClick={() => setActivePage('help')}
+          >
+            Help
           </button>
 
           <div className="graphs-menu">
@@ -614,27 +655,10 @@ export default function App() {
         )}
         {activePage === 'graphs' && (
           <>
-            <div className="chart-box">
-              <div className="formula-list">
-                <p>R1 = 1 - 0.3 (v - v0) = {R1.toFixed(2)}</p>
-                <p>
-                  R2 = 1 / (1 + (0.083 * v<sup>1.8</sup>) / (j * L<sup>2/3</sup>)) =
-                  {R2.toFixed(2)}
-                </p>
-                <p>Q1* = Q1 × R1 = {Q1_star.toFixed(2)}</p>
-                <p>Q2 = Q - Q1 = {Q2.toFixed(2)}</p>
-                <p>Q2* = Q2 × R2 = {Q2_star.toFixed(2)}</p>
-                <p>E = (Q1* + Q2*) / Q = {E.toFixed(2)}</p>
-                <p>E formula = R1 × E0 + R2 × (1 - E0) = {E_formula.toFixed(2)}</p>
-              </div>
-            </div>
-
-
             {widgetOrder.map((w) => (visibleCharts[w] ? widgetMap[w] : null))}
-
-
           </>
         )}
+        {activePage === 'help' && <Help />}
 
       </div>
     </div>

--- a/src/Help.jsx
+++ b/src/Help.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+export default function Help() {
+  return (
+    <div className="p-4 space-y-2">
+      <h1>Aiuto</h1>
+      <p>
+        Questa applicazione permette di calcolare l'efficienza idraulica delle caditoie
+        stradali e visualizzarla tramite diversi grafici.
+      </p>
+      <h2>Come utilizzare l'interfaccia</h2>
+      <ul className="list-disc pl-6 space-y-1">
+        <li>
+          Usa gli slider nella pagina <strong>Parametri</strong> per impostare i valori di input.
+        </li>
+        <li>
+          Passa alla pagina <strong>Simulazione</strong> per vedere i grafici.
+        </li>
+        <li>Ogni grafico è contenuto in un widget che puoi:</li>
+        <ul className="list-disc pl-6">
+          <li>ridimensionare trascinando l'angolo in basso a destra;</li>
+          <li>trascinare per modificare l'ordine dei grafici;</li>
+          <li>minimizzare o espandere con il pulsante '-'/'+' nella barra del widget.</li>
+        </ul>
+        <li>
+          Nella sidebar puoi attivare o disattivare i singoli grafici dalla sezione
+          <strong> Aspetto</strong>.
+        </li>
+        <li>
+          Le voci della sezione <strong>Azioni</strong> permettono di esportare i dati o
+          salvare/caricare i parametri.
+        </li>
+        <li>
+          Usa il pulsante nella parte alta destra della sidebar per aprirla o chiuderla.
+        </li>
+      </ul>
+      <p>Per ulteriori dettagli consulta il file README.md.</p>
+    </div>
+  );
+}

--- a/src/Widget.css
+++ b/src/Widget.css
@@ -18,3 +18,14 @@
   min-height: 150px;
   position: relative;
 }
+
+.widget::after {
+  content: '';
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  width: 16px;
+  height: 16px;
+  background: repeating-linear-gradient(45deg, #aaa, #aaa 2px, transparent 2px, transparent 4px);
+  pointer-events: none;
+}

--- a/src/__tests__/AppComponent.test.jsx
+++ b/src/__tests__/AppComponent.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import App from '../App';
 import '@testing-library/jest-dom';
 
@@ -12,6 +12,7 @@ describe('App component calculations', () => {
 
   test('shows line chart toggle', () => {
     render(<App />);
+    fireEvent.click(screen.getByText('Aspetto'));
     expect(screen.getByText(/Grafico a linee/)).toBeInTheDocument();
   });
 
@@ -31,6 +32,7 @@ describe('App component calculations', () => {
 
   test('export buttons are visible', () => {
     render(<App />);
+    fireEvent.click(screen.getByText('Azioni'));
     expect(screen.getByText('Esporta CSV')).toBeInTheDocument();
     expect(screen.getByText('Esporta Excel')).toBeInTheDocument();
     expect(screen.getByText('Salva parametri')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add Help.jsx page
- make results box draggable and resizable
- keep appearance/actions menus collapsed initially
- add Help item in the sidebar and fixed toggle when collapsed
- make resize handles visible on widgets
- add spacing on the right pane
- update related tests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f3142a6c832fab157d9619b8847c