### PR TITLE
Improve widget size and controls

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -9,7 +9,7 @@ Questa applicazione permette di calcolare l'efficienza idraulica delle caditoie 
 - Ogni grafico è contenuto in un *widget* che puoi:
   - ridimensionare trascinando l'angolo in basso a destra;
   - trascinare per modificare l'ordine dei grafici;
-  - minimizzare o espandere con il pulsante `-`/`+` nella barra del widget.
+  - minimizzare o espandere con il pulsante `➖`/`➕` nella barra del widget.
 - Nella sidebar puoi attivare o disattivare i singoli grafici dalla sezione **Aspetto**.
 - Le voci della sezione **Azioni** permettono di esportare i dati o salvare/caricare i parametri; sono visualizzate come semplici etichette cliccabili.
 - Usa il pulsante nella parte alta destra della sidebar per aprirla o chiuderla.

--- a/src/Help.jsx
+++ b/src/Help.jsx
@@ -20,7 +20,7 @@ export default function Help() {
         <ul className="list-disc pl-6">
           <li>ridimensionare trascinando l'angolo in basso a destra;</li>
           <li>trascinare per modificare l'ordine dei grafici;</li>
-          <li>minimizzare o espandere con il pulsante '-'/'+' nella barra del widget.</li>
+          <li>minimizzare o espandere con il pulsante '➖'/'➕' nella barra del widget.</li>
         </ul>
         <li>
           Nella sidebar puoi attivare o disattivare i singoli grafici dalla sezione

--- a/src/Widget.css
+++ b/src/Widget.css
@@ -9,13 +9,17 @@
   background: none;
   border: none;
   cursor: pointer;
+  width: 24px;
+  height: 24px;
+  font-size: 1.5em;
+  line-height: 24px;
 }
 
 .widget {
   resize: both;
-  overflow: auto;
-  min-width: 200px;
-  min-height: 150px;
+  overflow: visible;
+  min-width: 300px;
+  min-height: 350px;
   position: relative;
 }
 
@@ -24,8 +28,8 @@
   position: absolute;
   right: 2px;
   bottom: 2px;
-  width: 16px;
-  height: 16px;
+  width: 24px;
+  height: 24px;
   background: repeating-linear-gradient(45deg, #aaa, #aaa 2px, transparent 2px, transparent 4px);
   pointer-events: none;
 }

--- a/src/Widget.jsx
+++ b/src/Widget.jsx
@@ -23,7 +23,7 @@ const Widget = forwardRef(function Widget(
       <div className="widget-header">
         <span>{title}</span>
         <button onClick={() => setCollapsed((c) => !c)} aria-label="toggle widget">
-          {collapsed ? '+' : '-'}
+          {collapsed ? '➕' : '➖'}
         </button>
       </div>
       {!collapsed && (


### PR DESCRIPTION
## Summary
- enlarge widget toggle icons and resizer
- default widget size fits charts without scrollbars
- update HELP docs accordingly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f91e6aa8832f964928359c2dfa19