### PR TITLE
Fix widget spacing and collapse

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -13,16 +13,16 @@ body.dark-mode {
 
 .container {
   display: flex;
-  height: calc(100vh - 40px);
+  height: calc(100vh - 60px);
   position: relative;
-  padding-top: 40px;
+  padding-top: 60px;
   box-sizing: border-box;
 }
 
 .leftPane {
   overflow: auto;
   padding: 20px;
-  padding-top: 80px;
+  padding-top: 100px;
   transition: transform 0.3s ease, flex-basis 0.3s ease;
 }
 
@@ -34,7 +34,7 @@ body.dark-mode {
 .rightPane {
   flex-grow: 1;
   overflow: auto;
-  padding: 80px 20px 20px;
+  padding: 100px 20px 20px;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 20px;

--- a/src/Widget.css
+++ b/src/Widget.css
@@ -2,7 +2,9 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding-bottom: 5px;
   margin-bottom: 5px;
+  border-bottom: 1px solid #ccc;
 }
 
 .widget-header button {
@@ -21,6 +23,11 @@
   min-width: 300px;
   min-height: 350px;
   position: relative;
+}
+
+.widget.collapsed {
+  min-height: 50px;
+  height: auto;
 }
 
 .widget::after {

--- a/src/Widget.jsx
+++ b/src/Widget.jsx
@@ -8,7 +8,7 @@ const Widget = forwardRef(function Widget(
   const [collapsed, setCollapsed] = useState(false);
   return (
     <div
-      className="chart-box widget"
+      className={`chart-box widget${collapsed ? ' collapsed' : ''}`}
       draggable
       onDragStart={() => onDragStart && onDragStart(id)}
       onDrop={(e) => {
@@ -23,7 +23,7 @@ const Widget = forwardRef(function Widget(
       <div className="widget-header">
         <span>{title}</span>
         <button onClick={() => setCollapsed((c) => !c)} aria-label="toggle widget">
-          {collapsed ? '➕' : '➖'}
+          {collapsed ? '+' : '-'}
         </button>
       </div>
       {!collapsed && (


### PR DESCRIPTION
## Summary
- push widgets down a bit from the top
- add border below widget headers
- shrink widget box when collapsed and revert +/- icons

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fd540bb4832f8436807c4de77476