### PR TITLE
Fix widget drag to allow resize

### DIFF
--- a/src/Widget.jsx
+++ b/src/Widget.jsx
@@ -9,8 +9,6 @@ const Widget = forwardRef(function Widget(
   return (
     <div
       className={`chart-box widget${collapsed ? ' collapsed' : ''}`}
-      draggable
-      onDragStart={() => onDragStart && onDragStart(id)}
       onDrop={(e) => {
         e.preventDefault();
         onDrop && onDrop(id);
@@ -20,7 +18,11 @@ const Widget = forwardRef(function Widget(
         onDragOver && onDragOver(id);
       }}
     >
-      <div className="widget-header">
+      <div
+        className="widget-header"
+        draggable
+        onDragStart={() => onDragStart && onDragStart(id)}
+      >
         <span>{title}</span>
         <button onClick={() => setCollapsed((c) => !c)} aria-label="toggle widget">
           {collapsed ? '+' : '-'}


### PR DESCRIPTION
## Summary
- ensure resizing works by making only the header draggable

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540184183c832f9813f4108e3ce058