### PR TITLE
Add GitHub link and remove resize overlay

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -431,6 +431,23 @@ export default function App() {
         <img src={logo} alt="Logo" className="w-6 h-6" />
         <span className="font-semibold">Efficienza Caditoie</span>
         <span>- Pietro Ricciardi -</span>
+        <a
+          href="https://github.com/Pietro-Ricciardi"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <svg
+            className="w-5 h-5"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.01.08-2.11 0 0 .67-.21 2.2.82a7.56 7.56 0 012-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.91.08 2.11.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+            />
+          </svg>
+        </a>
         <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noreferrer" className="mr-4">
           Licenza MIT
         </a>

--- a/src/Widget.css
+++ b/src/Widget.css
@@ -30,13 +30,3 @@
   height: auto;
 }
 
-.widget::after {
-  content: '';
-  position: absolute;
-  right: 2px;
-  bottom: 2px;
-  width: 24px;
-  height: 24px;
-  background: repeating-linear-gradient(45deg, #aaa, #aaa 2px, transparent 2px, transparent 4px);
-  pointer-events: none;
-}


### PR DESCRIPTION
## Summary
- show GitHub link in the page header
- remove diagonal striped overlay from resizable widgets

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854032aab8c832f80c8bfd04dfb702a