### PR TITLE
Add tests for widget interactions

### DIFF
--- a/src/__tests__/widgetInteraction.test.jsx
+++ b/src/__tests__/widgetInteraction.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from '../App';
+
+describe('component interactions', () => {
+  test('dark mode toggle adds class to body', () => {
+    render(<App />);
+    expect(document.body).not.toHaveClass('dark-mode');
+    const toggle = screen.getByRole('button', { name: '🌙' });
+    fireEvent.click(toggle);
+    expect(document.body).toHaveClass('dark-mode');
+    expect(screen.getByRole('button', { name: '☀️' })).toBeInTheDocument();
+  });
+
+  test('widgets reorder on drag and drop', () => {
+    const { container } = render(<App />);
+    const getTitles = () =>
+      Array.from(container.querySelectorAll('.widget-header span')).map((el) =>
+        el.textContent
+      );
+
+    // initial order
+    expect(getTitles()[0]).toBe('Risultati');
+
+    const pieHeader = screen.getByText('Portate intercettate');
+    const resultsWidget = screen.getByText('Risultati').closest('.widget');
+
+    fireEvent.dragStart(pieHeader.parentElement);
+    fireEvent.drop(resultsWidget);
+
+    expect(getTitles()[0]).toBe('Portate intercettate');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for dark mode toggling and widget drag-and-drop

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685424ee12c8832fbe533cfe013514cc