### PR TITLE
Add ESLint and Prettier setup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    node: true
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'prettier'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['react'],
+  rules: {},
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  }
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none"
+}

--- a/README.md
+++ b/README.md
@@ -42,14 +42,24 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
    npm run dev
    ```
 
-3. Apri il browser su `http://localhost:5173`
+3. (Opzionale) Verifica lo stile del codice:
+   ```bash
+   npm run lint
+   ```
 
-4. (Opzionale) Esegui i test:
+4. (Opzionale) Applica la formattazione:
+   ```bash
+   npm run format
+   ```
+
+5. Apri il browser su `http://localhost:5173`
+
+6. (Opzionale) Esegui i test:
    ```bash
    npm test
    ```
 
-5. (Opzionale) Visualizza l'anteprima della build:
+7. (Opzionale) Visualizza l'anteprima della build:
    ```bash
    npm run preview
    ```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint \"**/*.{js,jsx}\"",
+    "format": "prettier --write \"**/*.{js,jsx,css,md}\""
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -22,6 +24,11 @@
     "babel-jest": "^29.7.0",
     "@babel/preset-env": "^7.22.20",
     "@babel/preset-react": "^7.22.5",
-    "identity-obj-proxy": "^3.0.0"
+    "identity-obj-proxy": "^3.0.0",
+    "eslint": "^8.56.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "prettier": "^3.2.5"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint configuration
- add Prettier configuration
- expose `lint` and `format` npm scripts
- document how to lint and format the project

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing eslint config for global eslint)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685425d077e0832f9b8a13531e5570ff