### PR TITLE
Improve JSON parse errors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -255,9 +255,11 @@ export default function App() {
   };
 
   const caricaParametriStorage = () => {
-    const loaded = caricaParametri('savedParams');
-    if (loaded) {
-      setParams(loaded);
+    const { data, error } = caricaParametri('savedParams');
+    if (data) {
+      setParams(data);
+    } else if (error) {
+      addToast(error.message);
     }
   };
 

--- a/src/__tests__/storage.test.js
+++ b/src/__tests__/storage.test.js
@@ -4,7 +4,15 @@ describe('salvaParametri e caricaParametri', () => {
   test('salva e ricarica dallo storage', () => {
     const params = { Q: 1 };
     salvaParametri('test', params);
-    const loaded = caricaParametri('test');
-    expect(loaded).toEqual(params);
+    const { data, error } = caricaParametri('test');
+    expect(error).toBeNull();
+    expect(data).toEqual(params);
+  });
+
+  test('gestisce JSON non valido', () => {
+    localStorage.setItem('bad', '{');
+    const { data, error } = caricaParametri('bad');
+    expect(data).toBeNull();
+    expect(error).toBeInstanceOf(Error);
   });
 });

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -3,20 +3,31 @@ export function salvaParametri(key, params) {
   localStorage.setItem(key, JSON.stringify(params));
 }
 
-export function caricaParametri(key) {
-  if (!key) return null;
-  const data = localStorage.getItem(key);
-  if (!data) return null;
+function parseJsonSafe(text, source) {
   try {
-    return JSON.parse(data);
-  } catch (e) {
-    return null;
+    return { data: JSON.parse(text), error: null };
+  } catch (err) {
+    return {
+      data: null,
+      error: new Error(`Errore parsing JSON da ${source}: ${err.message}`)
+    };
   }
+}
+
+export function caricaParametri(key) {
+  if (!key) {
+    return { data: null, error: new Error('Chiave non valida') };
+  }
+  const data = localStorage.getItem(key);
+  if (!data) {
+    return { data: null, error: new Error(`Nessun dato trovato per ${key}`) };
+  }
+  return parseJsonSafe(data, 'localStorage');
 }
 
 export function esportaParametri(params) {
   const blob = new Blob([JSON.stringify(params, null, 2)], {
-    type: 'application/json',
+    type: 'application/json'
   });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
@@ -35,7 +46,7 @@ export function importaParametri(file) {
         const params = JSON.parse(e.target.result);
         resolve(params);
       } catch (err) {
-        reject(err);
+        reject(new Error(`Errore parsing JSON dal file: ${err.message}`));
       }
     };
     reader.onerror = () => reject(new Error('Errore lettura file'));


### PR DESCRIPTION
## Summary
- add `parseJsonSafe` helper for storage utilities
- return detailed errors from `caricaParametri`
- propagate parse errors in `importaParametri`
- handle new return shape in the app
- update storage tests for new behavior

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_685426d5e2f0832f97d3ca5b7fa0a4e7