### PR TITLE
Add PropTypes to key components

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "recharts": "^2.7.2"
+    "recharts": "^2.7.2",
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/Toast.jsx
+++ b/src/Toast.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
 
 export default function Toast({ message, onClose }) {
   useEffect(() => {
@@ -10,3 +11,8 @@ export default function Toast({ message, onClose }) {
     <div className="bg-red-500 text-white px-3 py-2 rounded shadow">{message}</div>
   );
 }
+
+Toast.propTypes = {
+  message: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/Widget.jsx
+++ b/src/Widget.jsx
@@ -1,4 +1,5 @@
 import React, { useState, forwardRef } from 'react';
+import PropTypes from 'prop-types';
 import './Widget.css';
 
 const Widget = forwardRef(function Widget(
@@ -36,5 +37,14 @@ const Widget = forwardRef(function Widget(
     </div>
   );
 });
+
+Widget.propTypes = {
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  title: PropTypes.node.isRequired,
+  children: PropTypes.node,
+  onDragStart: PropTypes.func,
+  onDrop: PropTypes.func,
+  onDragOver: PropTypes.func,
+};
 
 export default Widget;


### PR DESCRIPTION
## Summary
- add `prop-types` runtime dependency
- annotate `Toast` and `Widget` components with PropTypes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685427e3ae88832f813c04ba331cc0b0