### PR TITLE
Add evolution table widget

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -11,6 +11,7 @@ Questa applicazione permette di calcolare l'efficienza idraulica delle caditoie 
   - trascinare per modificare l'ordine dei grafici;
   - minimizzare o espandere con il pulsante `➖`/`➕` nella barra del widget.
 - Nella sidebar puoi attivare o disattivare i singoli grafici dalla sezione **Aspetto**.
+- Tra questi è disponibile anche la **tabella evolutiva** dei valori calcolati.
 - Le voci della sezione **Azioni** permettono di esportare i dati o salvare/caricare i parametri; sono visualizzate come semplici etichette cliccabili.
 - Usa il pulsante nella parte alta destra della sidebar per aprirla o chiuderla.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
 
 - Visualizzazione su **grafico radar** dinamico.
 - Grafico evolutivo per Q o v su intervalli definiti.
+- Tabella dell'andamento per Q o v sugli stessi intervalli.
 - Modalità chiaro/scuro con pulsante di attivazione.
 - Layout responsive con possibilità di ridimensionare i pannelli.
 - Widget grafici minimizzabili, spostabili e ridimensionabili.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -141,6 +141,7 @@ export default function App() {
     pie: true,
     line: true,
     evolution: true,
+    evolutionTable: true,
     results: true,
   });
   const [widgetOrder, setWidgetOrder] = useState([
@@ -150,6 +151,7 @@ export default function App() {
     'pie',
     'line',
     'evolution',
+    'evolutionTable',
   ]);
   const [dragging, setDragging] = useState(null);
   const [appearanceOpen, setAppearanceOpen] = useState(false);

--- a/src/__tests__/evolutionTable.test.jsx
+++ b/src/__tests__/evolutionTable.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from '../App';
+
+describe('evolution table widget', () => {
+  test('renders table with calculated values', () => {
+    render(<App />);
+    const table = screen.getByRole('table');
+    const headers = within(table).getAllByRole('columnheader');
+    expect(headers[0]).toHaveTextContent('v');
+    expect(headers[1]).toHaveTextContent('Efficienza');
+
+    const rows = within(table).getAllByRole('row');
+    expect(rows).toHaveLength(6);
+    expect(rows[1].cells[0]).toHaveTextContent('0.50');
+    expect(rows[1].cells[1]).toHaveTextContent('0.77');
+  });
+});

--- a/src/components/EvolutionTable.jsx
+++ b/src/components/EvolutionTable.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function EvolutionTable({ evolutionData, rangeVar }) {
+  const header = rangeVar === 'Q' ? 'Q (l/s)' : 'v (m/s)';
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>{header}</th>
+          <th>Efficienza</th>
+        </tr>
+      </thead>
+      <tbody>
+        {evolutionData.map((row, idx) => (
+          <tr key={idx}>
+            <td>{row[rangeVar].toFixed(2)}</td>
+            <td>{row.efficiency.toFixed(2)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+EvolutionTable.propTypes = {
+  evolutionData: PropTypes.arrayOf(PropTypes.object).isRequired,
+  rangeVar: PropTypes.string.isRequired
+};

--- a/src/components/Graphs.jsx
+++ b/src/components/Graphs.jsx
@@ -20,6 +20,7 @@ import {
   LabelList,
 } from 'recharts';
 import Widget from '../Widget';
+import EvolutionTable from './EvolutionTable';
 
 export default function Graphs({
   R1,
@@ -180,6 +181,16 @@ export default function Graphs({
             </Line>
           </LineChart>
         </ResponsiveContainer>
+      </Widget>
+    ),
+    evolutionTable: (
+      <Widget
+        id="evolutionTable"
+        title={`Tabella evolutiva (${rangeVar})`}
+        onDragStart={handleDragStart}
+        onDrop={handleDrop}
+      >
+        <EvolutionTable evolutionData={evolutionData} rangeVar={rangeVar} />
       </Widget>
     ),
   };

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -81,6 +81,10 @@ export default function Sidebar({
                 <span className="w-4">{visibleCharts.evolution ? '✓' : ''}</span>
                 Grafico evolutivo
               </button>
+              <button className="submenu-item w-full text-left flex items-center" onClick={() => toggleChart('evolutionTable')}>
+                <span className="w-4">{visibleCharts.evolutionTable ? '✓' : ''}</span>
+                Tabella evolutiva
+              </button>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- add EvolutionTable component for table display of evolution data
- allow toggling of the new widget from sidebar
- enable default visibility/order for evolutionTable in App state
- add widget entry in Graphs
- document the table widget in README and HELP
- test for table rendering
- refine table header units

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542fd9972c832f86fd94398d5e4f08