### PR TITLE
Add OpenWeatherMap rainfall option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
 - Esportazione dei dati e dei grafici in **CSV**, **Excel** e come immagini.
 - Salvataggio e caricamento dei parametri in locale o tramite file JSON.
 - Download dei modelli **CSV**, **Excel** e **JSON** per l'import dei parametri.
+- Opzionalmente è possibile scegliere "OpenWeatherMap" come origine dei dati e
+  caricare automaticamente l'intensità di pioggia per una città, con
+  aggiornamento dei grafici in tempo reale.
 
 ## Avvio locale
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import Toast from "./Toast";
 import ParameterControls from "./components/ParameterControls";
 import Graphs from "./components/Graphs";
 import Sidebar from "./components/Sidebar";
+import { fetchRain } from "./utils/weather";
 
 export default function App() {
   const [params, setParams] = useState({
@@ -70,6 +71,9 @@ export default function App() {
   const [rangeMin, setRangeMin] = useState(0.5);
   const [rangeMax, setRangeMax] = useState(3);
   const [evolutionData, setEvolutionData] = useState([]);
+  const [dataSource, setDataSource] = useState('manual');
+  const [city, setCity] = useState('');
+  const [rain, setRain] = useState(null);
 
   const radarRef = useRef(null);
   const barRef = useRef(null);
@@ -104,6 +108,18 @@ export default function App() {
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
+
+  useEffect(() => {
+    if (dataSource === 'openweather' && city) {
+      const key = import.meta.env.VITE_OPENWEATHER_KEY || 'YOUR_API_KEY';
+      fetchRain(city, key)
+        .then((r) => {
+          setRain(r);
+          setParams((p) => ({ ...p, Q: r, Q1: r * 0.6 }));
+        })
+        .catch(() => addToast('Errore caricamento dati meteo'));
+    }
+  }, [dataSource, city, addToast]);
 
 
   const R1 = useMemo(() => calcR1(params.v, params.v0), [params]);
@@ -396,6 +412,11 @@ export default function App() {
             setRangeMin={setRangeMin}
             rangeMax={rangeMax}
             setRangeMax={setRangeMax}
+            dataSource={dataSource}
+            setDataSource={setDataSource}
+            city={city}
+            setCity={setCity}
+            rain={rain}
           />
         )}
         {activePage === 'graphs' && (

--- a/src/components/ParameterControls.jsx
+++ b/src/components/ParameterControls.jsx
@@ -22,9 +22,47 @@ export default function ParameterControls({
   setRangeMin,
   rangeMax,
   setRangeMax,
+  dataSource,
+  setDataSource,
+  city,
+  setCity,
+  rain,
 }) {
   return (
     <>
+      <div className="data-source">
+        <label>
+          <input
+            type="radio"
+            value="manual"
+            checked={dataSource === 'manual'}
+            onChange={() => setDataSource('manual')}
+          />
+          Manuale
+        </label>
+        <label>
+          <input
+            type="radio"
+            value="openweather"
+            checked={dataSource === 'openweather'}
+            onChange={() => setDataSource('openweather')}
+          />
+          OpenWeatherMap
+        </label>
+        {dataSource === 'openweather' && (
+          <div className="weather-input">
+            <input
+              type="text"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              placeholder="Città"
+            />
+            <span>
+              Pioggia: {rain != null ? `${rain.toFixed(2)} mm/h` : 'n/d'}
+            </span>
+          </div>
+        )}
+      </div>
       {Object.entries(params).map(([key, value]) => {
         const min = 0;
         const max =
@@ -119,4 +157,9 @@ ParameterControls.propTypes = {
   setRangeMin: PropTypes.func.isRequired,
   rangeMax: PropTypes.number.isRequired,
   setRangeMax: PropTypes.func.isRequired,
+  dataSource: PropTypes.string.isRequired,
+  setDataSource: PropTypes.func.isRequired,
+  city: PropTypes.string.isRequired,
+  setCity: PropTypes.func.isRequired,
+  rain: PropTypes.number,
 };

--- a/src/utils/weather.js
+++ b/src/utils/weather.js
@@ -1,0 +1,11 @@
+export async function fetchRain(city, apiKey) {
+  const url = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&appid=${apiKey}&units=metric`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Errore richiesta OpenWeatherMap');
+  }
+  const data = await res.json();
+  // valore pioggia in mm/h, preferisci 1h se disponibile, altrimenti 3h
+  const rain = data.rain?.['1h'] ?? data.rain?.['3h'] ?? 0;
+  return rain;
+}


### PR DESCRIPTION
## Summary
- integrate fetchRain helper for OpenWeatherMap
- allow choosing manual data or OpenWeatherMap in parameter controls
- update App to use new weather functionality
- document weather feature in README

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_685436207a54832fa0eb198091876058