### PR TITLE
Add Normativa menu with reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Questo è un progetto React che consente di calcolare e visualizzare l'efficienz
 Un file Excel di esempio è disponibile nella cartella `excel`.
 Nella directory `public/templates` sono presenti i modelli **CSV**, **Excel** e **JSON** da compilare per caricare i parametri nell'applicazione.
 
-Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o la sezione **Help** dell'applicazione.
+Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o la sezione **Help** dell'applicazione. È presente inoltre un menu **Normativa** con i collegamenti alle principali norme UNI, EN e ISO di settore.
 
 ## Funzionalità
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import {
   importaParametri,
 } from "./utils/storage";
 import Help from "./Help";
+import Normativa from "./Normativa";
 import Toast from "./Toast";
 import ParameterControls from "./components/ParameterControls";
 import Graphs from "./components/Graphs";
@@ -447,6 +448,7 @@ export default function App() {
           />
         )}
         {activePage === 'help' && <Help />}
+        {activePage === 'normativa' && <Normativa />}
 
       </div>
       </div>

--- a/src/Normativa.jsx
+++ b/src/Normativa.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+
+export default function Normativa() {
+  return (
+    <div className="p-4 space-y-2">
+      <h1>Normativa</h1>
+      <h2>Norme Europee (EN)</h2>
+      <ul className="list-disc pl-6 space-y-1">
+        <li>
+          <a
+            href="https://standards.cen.eu/dyn/www/f?p=204:110:0::::FSP_PROJECT,FSP_ORG_ID:13174,6121&cs=14A3B4B8D8B878E09F04DE95464A9D30A"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            EN 1433: Drainage channels for vehicular and pedestrian areas — Design and testing
+          </a>
+          : definisce requisiti, classificazione e metodi di prova per canalette e griglie in aree carrabili e pedonali.
+        </li>
+        <li>
+          <a
+            href="https://standards.cen.eu/dyn/www/f?p=204:110:0::::FSP_PROJECT,FSP_ORG_ID:8384,6121&cs=124E0E4B0A5E654F3E1289B7F1E1B84B"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            EN 124: Gully tops and manhole tops for vehicular and pedestrian areas — Classification, performance requirements and test methods
+          </a>
+          : riguarda le caditoie a bocca di lupo installate a filo strada o marciapiede, con classi di carico fino a F900.
+        </li>
+      </ul>
+      <h2>Norme Internazionali (ISO)</h2>
+      <ul className="list-disc pl-6 space-y-1">
+        <li>
+          <a
+            href="https://www.iso.org/standard/75090.html"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ISO 22282-1: Test method for drainage channel gratings — Part 1: Determination of hydraulic characteristics
+          </a>
+          : specifica il metodo per misurare portata e rendimento idraulico delle griglie.
+        </li>
+        <li>
+          <a
+            href="https://www.iso.org/standard/75091.html"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ISO 22282-2: Test method for drainage channel gratings — Part 2: Determination of mechanical characteristics
+          </a>
+          : definizioni dei carichi di prova e criteri di resistenza meccanica.
+        </li>
+      </ul>
+      <h2>Norme Italiane (UNI)</h2>
+      <ul className="list-disc pl-6 space-y-1">
+        <li>
+          <a
+            href="https://store.uni.com/catalogo/index.php/uni-en-1433-2008?inv=3958346"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            UNI EN 1433:2008
+          </a>
+          : recepimento italiano della EN 1433.
+        </li>
+        <li>
+          <a
+            href="https://store.uni.com/catalogo/index.php/uni-11583-2015?inv=4847692"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            UNI 11583:2015
+          </a>
+          : manufatti di pozzetti stradali e caditoie di raccolta per reti di drenaggio, specifiche per materiali compositi.
+        </li>
+        <li>
+          <a
+            href="https://store.uni.com/catalogo/index.php/uni-11307-2010?inv=2302458"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            UNI 11307:2010
+          </a>
+          : dimensionamento idraulico delle caditoie per la raccolta delle acque meteoriche.
+        </li>
+      </ul>
+      <h2>Portali di acquisto e consultazione</h2>
+      <ul className="list-disc pl-6 space-y-1">
+        <li>
+          <a href="https://www.uni.com" target="_blank" rel="noopener noreferrer">UNI (Ente Italiano di Normazione)</a>
+          : ricerca per numero norma ed acquisto di PDF o copie cartacee.
+        </li>
+        <li>
+          <a href="https://www.cen.eu" target="_blank" rel="noopener noreferrer">CEN (Comitato Europeo di Normazione)</a>
+          : catalogo norme EN.
+        </li>
+        <li>
+          <a href="https://www.iso.org" target="_blank" rel="noopener noreferrer">ISO (International Organization for Standardization)</a>
+          : catalogo norme ISO.
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/__tests__/AppComponent.test.jsx
+++ b/src/__tests__/AppComponent.test.jsx
@@ -38,4 +38,10 @@ describe('App component calculations', () => {
     expect(screen.getByText('Salva parametri')).toBeInTheDocument();
   });
 
+  test('normativa page is reachable', () => {
+    render(<App />);
+    fireEvent.click(screen.getByText('Normativa'));
+    expect(screen.getByText('Norme Europee (EN)')).toBeInTheDocument();
+  });
+
 });

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -57,6 +57,13 @@ export default function Sidebar({
           Help
         </button>
 
+        <button
+          className="px-4 py-2 text-left hover:bg-gray-100 w-full"
+          onClick={() => setActivePage('normativa')}
+        >
+          Normativa
+        </button>
+
         <div className="graphs-menu">
           <button
             className="px-4 py-2 text-left hover:bg-gray-100 w-full flex justify-between"


### PR DESCRIPTION
## Summary
- add a Normativa page listing EN, ISO and UNI standards
- expose the page through the sidebar menu
- render Normativa section in `App.jsx`
- mention the new menu in the README
- test that the Normativa page can be opened

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685438c6096c832fba3a3c5f54aa0fe3