### PR TITLE
Add env instructions and tweak weather selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
 ## Funzionalità
 
 - Inserimento dei parametri tramite **slider interattivi**:
+
   - Portata totale (Q)
   - Portata intercettata (Q1)
   - Velocità del flusso (v)
@@ -32,37 +33,48 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
 - Esportazione dei dati e dei grafici in **CSV**, **Excel** e come immagini.
 - Salvataggio e caricamento dei parametri in locale o tramite file JSON.
 - Download dei modelli **CSV**, **Excel** e **JSON** per l'import dei parametri.
+- Opzionalmente è possibile scegliere "OpenWeatherMap" come origine dei dati e
+  caricare automaticamente l'intensità di pioggia per una città, con
+  aggiornamento dei grafici in tempo reale.
 
 ## Avvio locale
 
 1. Installa le dipendenze:
+
    ```bash
    npm install
    ```
 
-2. Avvia il progetto:
+2. (Opzionale) copia `env.example` in `.env.local` e imposta `VITE_OPENWEATHER_KEY`
+   con la tua API key di OpenWeatherMap per abilitare i dati meteo.
+
+3. Avvia il progetto:
+
    ```bash
    npm run dev
    ```
 
-3. (Opzionale) Verifica lo stile del codice:
+4. (Opzionale) Verifica lo stile del codice:
+
    ```bash
    npm run lint
    ```
 
-4. (Opzionale) Applica la formattazione:
+5. (Opzionale) Applica la formattazione:
+
    ```bash
    npm run format
    ```
 
-5. Apri il browser su `http://localhost:5173`
+6. Apri il browser su `http://localhost:5173`
 
-6. (Opzionale) Esegui i test:
+7. (Opzionale) Esegui i test:
+
    ```bash
    npm test
    ```
 
-7. (Opzionale) Visualizza l'anteprima della build:
+8. (Opzionale) Visualizza l'anteprima della build:
    ```bash
    npm run preview
    ```
@@ -70,6 +82,7 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
 ## Deploy (consigliato: Vercel)
 
 1. Inizializza il repository Git:
+
    ```bash
    git init
    git add .
@@ -77,6 +90,7 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
    ```
 
 2. Crea un repository su [GitHub](https://github.com) e collegalo:
+
    ```bash
    git remote add origin https://github.com/tuo-username/efficienza-caditoie.git
    git push -u origin main

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
 - Opzionalmente è possibile scegliere "OpenWeatherMap" come origine dei dati e
   caricare automaticamente l'intensità di pioggia per una città, con
   aggiornamento dei grafici in tempo reale.
+  L'API key di OpenWeatherMap va inserita in un apposito campo password
+  dell'interfaccia. Tenendo premuta l'icona a forma di occhio si può
+  visualizzare temporaneamente la chiave per verificarne la correttezza. Solo
+  dopo la convalida della key è possibile specificare la città.
 
 ## Avvio locale
 
@@ -46,7 +50,8 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
    ```
 
 2. (Opzionale) copia `env.example` in `.env.local` e imposta `VITE_OPENWEATHER_KEY`
-   con la tua API key di OpenWeatherMap per abilitare i dati meteo.
+   con la tua API key di OpenWeatherMap: l'app la caricherà come valore
+   predefinito del campo nell'interfaccia.
 
 3. Avvia il progetto:
 

--- a/env.example
+++ b/env.example
@@ -1,0 +1,3 @@
+# Copia questo file in `.env.local` e inserisci la tua API key
+# per abilitare il caricamento delle precipitazioni da OpenWeatherMap
+VITE_OPENWEATHER_KEY=YOUR_API_KEY

--- a/src/App.css
+++ b/src/App.css
@@ -23,7 +23,9 @@ body.dark-mode {
   overflow: auto;
   padding: 20px;
   padding-top: 100px;
-  transition: transform 0.3s ease, flex-basis 0.3s ease;
+  transition:
+    transform 0.3s ease,
+    flex-basis 0.3s ease;
 }
 
 .leftPane.collapsed {
@@ -51,7 +53,6 @@ body.dark-mode {
   height: 5px;
   background: #ddd;
 }
-
 
 .theme-toggle {
   font-size: 1.5em;
@@ -260,7 +261,6 @@ body.dark-mode {
   margin-bottom: 5px;
 }
 
-
 .export-buttons {
   margin: 20px 0;
   display: flex;
@@ -275,4 +275,21 @@ body.dark-mode {
   text-align: left;
   color: inherit;
   cursor: pointer;
+}
+
+.data-source {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+
+.data-source .source-option {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.data-source .weather-input {
+  margin-top: 4px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -293,3 +293,22 @@ body.dark-mode {
 .data-source .weather-input {
   margin-top: 4px;
 }
+
+.api-key-field {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.eye-icon {
+  cursor: pointer;
+  user-select: none;
+}
+
+.api-ok {
+  color: green;
+}
+
+.api-warn {
+  color: red;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import Toast from "./Toast";
 import ParameterControls from "./components/ParameterControls";
 import Graphs from "./components/Graphs";
 import Sidebar from "./components/Sidebar";
+import { fetchRain } from "./utils/weather";
 
 export default function App() {
   const [params, setParams] = useState({
@@ -70,6 +71,9 @@ export default function App() {
   const [rangeMin, setRangeMin] = useState(0.5);
   const [rangeMax, setRangeMax] = useState(3);
   const [evolutionData, setEvolutionData] = useState([]);
+  const [dataSource, setDataSource] = useState('manual');
+  const [city, setCity] = useState('');
+  const [rain, setRain] = useState(null);
 
   const radarRef = useRef(null);
   const barRef = useRef(null);
@@ -104,6 +108,18 @@ export default function App() {
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
+
+  useEffect(() => {
+    if (dataSource === 'openweather' && city) {
+      const key = import.meta.env.VITE_OPENWEATHER_KEY || 'YOUR_API_KEY';
+      fetchRain(city, key)
+        .then((r) => {
+          setRain(r);
+          setParams((p) => ({ ...p, Q: r, Q1: r * 0.6 }));
+        })
+        .catch(() => addToast('Errore caricamento dati meteo'));
+    }
+  }, [dataSource, city, addToast]);
 
 
   const R1 = useMemo(() => calcR1(params.v, params.v0), [params]);
@@ -396,6 +412,11 @@ export default function App() {
             setRangeMin={setRangeMin}
             rangeMax={rangeMax}
             setRangeMax={setRangeMax}
+            dataSource={dataSource}
+            setDataSource={setDataSource}
+            city={city}
+            setCity={setCity}
+            rain={rain}
           />
         )}
         {activePage === 'graphs' && (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -72,6 +72,8 @@ export default function App() {
   const [rangeMax, setRangeMax] = useState(3);
   const [evolutionData, setEvolutionData] = useState([]);
   const [dataSource, setDataSource] = useState('manual');
+  const [apiKey, setApiKey] = useState(() => import.meta.env.VITE_OPENWEATHER_KEY || '');
+  const [apiKeyValid, setApiKeyValid] = useState(false);
   const [city, setCity] = useState('');
   const [rain, setRain] = useState(null);
 
@@ -110,16 +112,28 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    if (dataSource === 'openweather' && city) {
-      const key = import.meta.env.VITE_OPENWEATHER_KEY || 'YOUR_API_KEY';
-      fetchRain(city, key)
+    if (dataSource === 'openweather' && apiKey) {
+      fetchRain('Rome', apiKey)
+        .then(() => setApiKeyValid(true))
+        .catch(() => {
+          setApiKeyValid(false);
+          addToast('API key non valida');
+        });
+    } else {
+      setApiKeyValid(false);
+    }
+  }, [dataSource, apiKey, addToast]);
+
+  useEffect(() => {
+    if (dataSource === 'openweather' && apiKeyValid && city) {
+      fetchRain(city, apiKey)
         .then((r) => {
           setRain(r);
           setParams((p) => ({ ...p, Q: r, Q1: r * 0.6 }));
         })
         .catch(() => addToast('Errore caricamento dati meteo'));
     }
-  }, [dataSource, city, addToast]);
+  }, [dataSource, apiKeyValid, city, apiKey, addToast]);
 
 
   const R1 = useMemo(() => calcR1(params.v, params.v0), [params]);
@@ -414,6 +428,9 @@ export default function App() {
             setRangeMax={setRangeMax}
             dataSource={dataSource}
             setDataSource={setDataSource}
+            apiKey={apiKey}
+            setApiKey={setApiKey}
+            apiKeyValid={apiKeyValid}
             city={city}
             setCity={setCity}
             rain={rain}

--- a/src/components/ParameterControls.jsx
+++ b/src/components/ParameterControls.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const paramInfo = {
-  Q: "Portata totale del deflusso (l/s).",
-  Q1: "Porzione di Q che raggiunge direttamente la caditoia (l/s).",
+  Q: 'Portata totale del deflusso (l/s).',
+  Q1: 'Porzione di Q che raggiunge direttamente la caditoia (l/s).',
   v: "Velocità del flusso all'ingresso (m/s).",
-  v0: "Velocità di riferimento per il calcolo di R1 (m/s).",
-  j: "Pendenza longitudinale della strada.",
-  L: "Lunghezza della griglia di caduta (m).",
-  E0: "Efficienza geometrica della caditoia.",
+  v0: 'Velocità di riferimento per il calcolo di R1 (m/s).',
+  j: 'Pendenza longitudinale della strada.',
+  L: 'Lunghezza della griglia di caduta (m).',
+  E0: 'Efficienza geometrica della caditoia.'
 };
 
 export default function ParameterControls({
@@ -22,35 +22,75 @@ export default function ParameterControls({
   setRangeMin,
   rangeMax,
   setRangeMax,
+  dataSource,
+  setDataSource,
+  city,
+  setCity,
+  rain
 }) {
   return (
     <>
+      <div className="data-source">
+        <label className="source-option">
+          <input
+            type="radio"
+            value="manual"
+            checked={dataSource === 'manual'}
+            onChange={() => setDataSource('manual')}
+          />
+          Manuale
+        </label>
+        <label className="source-option">
+          <input
+            type="radio"
+            value="openweather"
+            checked={dataSource === 'openweather'}
+            onChange={() => setDataSource('openweather')}
+          />
+          OpenWeatherMap
+        </label>
+        {dataSource === 'openweather' && (
+          <div className="weather-input">
+            <input
+              type="text"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              placeholder="Città"
+            />
+            <span>
+              Pioggia: {rain != null ? `${rain.toFixed(2)} mm/h` : 'n/d'}
+            </span>
+          </div>
+        )}
+      </div>
       {Object.entries(params).map(([key, value]) => {
         const min = 0;
         const max =
           key === 'E0'
             ? 1
             : key === 'v' || key === 'v0'
-            ? 10
-            : key === 'j'
-            ? 0.2
-            : key === 'L'
-            ? 5
-            : 1000;
+              ? 10
+              : key === 'j'
+                ? 0.2
+                : key === 'L'
+                  ? 5
+                  : 1000;
         const step =
           key === 'E0' || key === 'L'
             ? 0.01
             : key === 'v' || key === 'v0'
-            ? 0.01
-            : key === 'j'
-            ? 0.001
-            : 0.1;
+              ? 0.01
+              : key === 'j'
+                ? 0.001
+                : 0.1;
         return (
           <div key={key} className="slider-container">
             <label className="slider-label">
               {key}: {value.toFixed(2)}
               <span className="info-wrapper">
-                <span className="info-icon" onClick={() => toggleInfo(key)}>i</span>
+                <span className="info-icon" onClick={() => toggleInfo(key)}>
+                  i
+                </span>
                 {infoParam === key && (
                   <div className="info-popup">{paramInfo[key]}</div>
                 )}
@@ -82,7 +122,10 @@ export default function ParameterControls({
       <div className="range-selector">
         <label>
           Variabile:
-          <select value={rangeVar} onChange={(e) => setRangeVar(e.target.value)}>
+          <select
+            value={rangeVar}
+            onChange={(e) => setRangeVar(e.target.value)}
+          >
             <option value="v">v</option>
             <option value="Q">Q</option>
           </select>
@@ -119,4 +162,9 @@ ParameterControls.propTypes = {
   setRangeMin: PropTypes.func.isRequired,
   rangeMax: PropTypes.number.isRequired,
   setRangeMax: PropTypes.func.isRequired,
+  dataSource: PropTypes.string.isRequired,
+  setDataSource: PropTypes.func.isRequired,
+  city: PropTypes.string.isRequired,
+  setCity: PropTypes.func.isRequired,
+  rain: PropTypes.number
 };

--- a/src/components/ParameterControls.jsx
+++ b/src/components/ParameterControls.jsx
@@ -24,10 +24,14 @@ export default function ParameterControls({
   setRangeMax,
   dataSource,
   setDataSource,
+  apiKey,
+  setApiKey,
+  apiKeyValid,
   city,
   setCity,
   rain
 }) {
+  const [showKey, setShowKey] = React.useState(false);
   return (
     <>
       <div className="data-source">
@@ -50,17 +54,44 @@ export default function ParameterControls({
           OpenWeatherMap
         </label>
         {dataSource === 'openweather' && (
-          <div className="weather-input">
-            <input
-              type="text"
-              value={city}
-              onChange={(e) => setCity(e.target.value)}
-              placeholder="Città"
-            />
-            <span>
-              Pioggia: {rain != null ? `${rain.toFixed(2)} mm/h` : 'n/d'}
-            </span>
-          </div>
+          <>
+            <div className="weather-input">
+              <div className="api-key-field">
+                <input
+                  type={showKey ? 'text' : 'password'}
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder="API key"
+                />
+                <span
+                  className="eye-icon"
+                  onMouseDown={() => setShowKey(true)}
+                  onMouseUp={() => setShowKey(false)}
+                  onMouseLeave={() => setShowKey(false)}
+                >
+                  👁
+                </span>
+              </div>
+              {apiKey && (
+                <span className={apiKeyValid ? 'api-ok' : 'api-warn'}>
+                  {apiKeyValid ? 'API key valida' : 'API key non valida'}
+                </span>
+              )}
+            </div>
+            {apiKeyValid && (
+              <div className="weather-input">
+                <input
+                  type="text"
+                  value={city}
+                  onChange={(e) => setCity(e.target.value)}
+                  placeholder="Città"
+                />
+                <span>
+                  Pioggia: {rain != null ? `${rain.toFixed(2)} mm/h` : 'n/d'}
+                </span>
+              </div>
+            )}
+          </>
         )}
       </div>
       {Object.entries(params).map(([key, value]) => {
@@ -164,6 +195,9 @@ ParameterControls.propTypes = {
   setRangeMax: PropTypes.func.isRequired,
   dataSource: PropTypes.string.isRequired,
   setDataSource: PropTypes.func.isRequired,
+  apiKey: PropTypes.string.isRequired,
+  setApiKey: PropTypes.func.isRequired,
+  apiKeyValid: PropTypes.bool.isRequired,
   city: PropTypes.string.isRequired,
   setCity: PropTypes.func.isRequired,
   rain: PropTypes.number

--- a/src/utils/weather.js
+++ b/src/utils/weather.js
@@ -1,0 +1,11 @@
+export async function fetchRain(city, apiKey) {
+  const url = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&appid=${apiKey}&units=metric`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Errore richiesta OpenWeatherMap');
+  }
+  const data = await res.json();
+  // valore pioggia in mm/h, preferisci 1h se disponibile, altrimenti 3h
+  const rain = data.rain?.['1h'] ?? data.rain?.['3h'] ?? 0;
+  return rain;
+}


### PR DESCRIPTION
## Summary
- style data source selector vertically in ParameterControls
- update app styles to support the new layout
- document OpenWeatherMap API key configuration in README
- provide `env.example` template for the API key

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685436207a54832fa0eb198091876058