### PR TITLE
Style evolution table as Excel grid

### DIFF
--- a/src/components/EvolutionTable.css
+++ b/src/components/EvolutionTable.css
@@ -1,0 +1,16 @@
+.evolution-table {
+  border-collapse: collapse;
+  margin: 0 auto;
+}
+
+.evolution-table th,
+.evolution-table td {
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+  text-align: center;
+}
+
+.dark-mode .evolution-table th,
+.dark-mode .evolution-table td {
+  border-color: #555;
+}

--- a/src/components/EvolutionTable.jsx
+++ b/src/components/EvolutionTable.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import './EvolutionTable.css';
 
 export default function EvolutionTable({ evolutionData, rangeVar }) {
   const header = rangeVar === 'Q' ? 'Q (l/s)' : 'v (m/s)';
 
   return (
-    <table>
+    <table className="evolution-table">
       <thead>
         <tr>
           <th>{header}</th>


### PR DESCRIPTION
## Summary
- display evolutionary table using Excel-like grid lines
- center the table inside its widget

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685440622b34832f9498f872dcf81dc0