### PR TITLE
Add API key verification for OpenWeather

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
 - Download dei modelli **CSV**, **Excel** e **JSON** per l'import dei parametri.
 - Opzionalmente è possibile scegliere "OpenWeatherMap" come origine dei dati e
   caricare automaticamente l'intensità di pioggia per una città, con
-  aggiornamento dei grafici in tempo reale.
+  aggiornamento dei grafici in tempo reale. Verrà richiesto di inserire la
+  propria **API key** di OpenWeatherMap; il campo è nascosto e la chiave può
+  essere mostrata temporaneamente tenendo premuta l'icona a forma di occhio.
+  Solo dopo la verifica della chiave sarà possibile specificare la città.
 
 ## Avvio locale
 

--- a/src/components/ParameterControls.jsx
+++ b/src/components/ParameterControls.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 const paramInfo = {
@@ -26,8 +26,13 @@ export default function ParameterControls({
   setDataSource,
   city,
   setCity,
+  apiKey,
+  setApiKey,
+  apiVerified,
+  verifyKey,
   rain,
 }) {
+  const [showKey, setShowKey] = useState(false);
   return (
     <>
       <div className="data-source">
@@ -50,17 +55,40 @@ export default function ParameterControls({
           OpenWeatherMap
         </label>
         {dataSource === 'openweather' && (
-          <div className="weather-input">
-            <input
-              type="text"
-              value={city}
-              onChange={(e) => setCity(e.target.value)}
-              placeholder="Città"
-            />
-            <span>
-              Pioggia: {rain != null ? `${rain.toFixed(2)} mm/h` : 'n/d'}
-            </span>
-          </div>
+          <>
+            <div className="api-key-input">
+              <div className="password-wrapper">
+                <input
+                  type={showKey ? 'text' : 'password'}
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder="API Key"
+                />
+                <span
+                  className="eye-icon"
+                  onMouseDown={() => setShowKey(true)}
+                  onMouseUp={() => setShowKey(false)}
+                  onMouseLeave={() => setShowKey(false)}
+                >
+                  &#128065;
+                </span>
+              </div>
+              {!apiVerified && <button onClick={verifyKey}>Verifica</button>}
+            </div>
+            {apiVerified && (
+              <div className="weather-input">
+                <input
+                  type="text"
+                  value={city}
+                  onChange={(e) => setCity(e.target.value)}
+                  placeholder="Città"
+                />
+                <span>
+                  Pioggia: {rain != null ? `${rain.toFixed(2)} mm/h` : 'n/d'}
+                </span>
+              </div>
+            )}
+          </>
         )}
       </div>
       {Object.entries(params).map(([key, value]) => {
@@ -161,5 +189,9 @@ ParameterControls.propTypes = {
   setDataSource: PropTypes.func.isRequired,
   city: PropTypes.string.isRequired,
   setCity: PropTypes.func.isRequired,
+  apiKey: PropTypes.string.isRequired,
+  setApiKey: PropTypes.func.isRequired,
+  apiVerified: PropTypes.bool.isRequired,
+  verifyKey: PropTypes.func.isRequired,
   rain: PropTypes.number,
 };

--- a/src/utils/weather.js
+++ b/src/utils/weather.js
@@ -9,3 +9,12 @@ export async function fetchRain(city, apiKey) {
   const rain = data.rain?.['1h'] ?? data.rain?.['3h'] ?? 0;
   return rain;
 }
+
+export async function verifyApiKey(apiKey) {
+  const url = `https://api.openweathermap.org/data/2.5/weather?q=Rome&appid=${apiKey}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Chiave API non valida');
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- require OpenWeatherMap API key before entering city
- add hold-to-show password field and verification button
- fetch weather data only after key verification

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854418ccff0832f948c0015a4b3d943