### PR TITLE
Add data source selector widget

### DIFF
--- a/src/components/ParameterControls.jsx
+++ b/src/components/ParameterControls.jsx
@@ -36,28 +36,28 @@ export default function ParameterControls({
   const [showKey, setShowKey] = useState(false);
   return (
     <>
-      <div className="data-source">
-        <label>
-          <input
-            type="radio"
-            value="manual"
-            checked={dataSource === 'manual'}
-            onChange={() => setDataSource('manual')}
-          />
-          Manuale
-        </label>
-        <label>
-          <input
-            type="radio"
-            value="openweather"
-            checked={dataSource === 'openweather'}
-            onChange={() => setDataSource('openweather')}
-          />
-          OpenWeatherMap
-        </label>
-      </div>
-      {dataSource === 'openweather' && (
-        <Widget id="owm" title="OpenWeatherMap">
+      <Widget id="owm" title="Fonte dati">
+        <div className="data-source">
+          <label>
+            <input
+              type="radio"
+              value="manual"
+              checked={dataSource === 'manual'}
+              onChange={() => setDataSource('manual')}
+            />
+            Manuale
+          </label>
+          <label>
+            <input
+              type="radio"
+              value="openweather"
+              checked={dataSource === 'openweather'}
+              onChange={() => setDataSource('openweather')}
+            />
+            OpenWeatherMap
+          </label>
+        </div>
+        {dataSource === 'openweather' && (
           <div className="api-key-input">
             <div className="password-wrapper">
               <input
@@ -91,7 +91,6 @@ export default function ParameterControls({
             </div>
           )}
         </Widget>
-      )}
       {Object.entries(params).map(([key, value]) => {
         const min = 0;
         const max =


### PR DESCRIPTION
## Summary
- place `Manuale` and `OpenWeatherMap` options inside a new `Fonte dati` widget
- show OpenWeatherMap fields only when that data source is selected

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6854fb3ee984832fa67f0a4e1d17ffda