### PR TITLE
Add sediment graphs component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -193,6 +193,7 @@ export default function App() {
     evolution: true,
     evolutionTable: true,
     results: true,
+    sediments: true,
   });
   const [widgetOrder, setWidgetOrder] = useState([
     'results',
@@ -202,6 +203,7 @@ export default function App() {
     'line',
     'evolution',
     'evolutionTable',
+    'sediments',
   ]);
   const [dragging, setDragging] = useState(null);
   const [appearanceOpen, setAppearanceOpen] = useState(false);
@@ -496,6 +498,7 @@ export default function App() {
             pieData={pieData}
             lineData={lineData}
             sedimentData={sedimentData}
+            params={params}
             evolutionData={evolutionData}
             rangeVar={rangeVar}
             visibleCharts={visibleCharts}

--- a/src/components/Graphs.jsx
+++ b/src/components/Graphs.jsx
@@ -21,6 +21,7 @@ import {
 } from 'recharts';
 import Widget from '../Widget';
 import EvolutionTable from './EvolutionTable';
+import SedimentGraphs from './SedimentGraphs';
 
 export default function Graphs({
   R1,
@@ -35,6 +36,7 @@ export default function Graphs({
   pieData,
   lineData,
   sedimentData,
+  params,
   evolutionData,
   rangeVar,
   visibleCharts,
@@ -194,6 +196,7 @@ export default function Graphs({
         <EvolutionTable evolutionData={evolutionData} rangeVar={rangeVar} />
       </Widget>
     ),
+    sediments: <SedimentGraphs params={params} sedimentData={sedimentData} />,
   };
 
   return <>{widgetOrder.map((w) => (visibleCharts[w] ? widgetMap[w] : null))}</>;
@@ -212,6 +215,7 @@ Graphs.propTypes = {
   pieData: PropTypes.array.isRequired,
   lineData: PropTypes.array.isRequired,
   sedimentData: PropTypes.object,
+  params: PropTypes.object.isRequired,
   evolutionData: PropTypes.array.isRequired,
   rangeVar: PropTypes.string.isRequired,
   visibleCharts: PropTypes.object.isRequired,

--- a/src/components/SedimentGraphs.jsx
+++ b/src/components/SedimentGraphs.jsx
@@ -1,0 +1,107 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  LabelList
+} from 'recharts';
+import Widget from '../Widget';
+import {
+  meyerPeterMuller,
+  einsteinBedload,
+  rouseProfile
+} from '../lib/sediment';
+
+export default function SedimentGraphs({ params, sedimentData }) {
+  const bedloadData = useMemo(() => {
+    const thetaC = 0.047;
+    const s = params.rhoS / 1000;
+    const thetaMax = Math.max(sedimentData.theta * 1.5, thetaC + 0.05);
+    const data = [];
+    for (let i = 0; i <= 20; i++) {
+      const theta = thetaC + (i / 20) * (thetaMax - thetaC);
+      data.push({
+        theta,
+        mpm: meyerPeterMuller(theta, thetaC, params.d50, s),
+        einstein: einsteinBedload(theta, thetaC, params.d50, s)
+      });
+    }
+    return data;
+  }, [params, sedimentData.theta]);
+
+  const concentrationData = useMemo(() => {
+    const h = params.h;
+    const za = 0.05 * h;
+    const ca = 0.01;
+    const zVals = Array.from(
+      { length: 20 },
+      (_, i) => za + (i / 19) * (h - za)
+    );
+    const cVals = rouseProfile(zVals, h, ca, za, sedimentData.rouseP);
+    return zVals.map((z, idx) => ({ z, c: cVals[idx] }));
+  }, [params.h, sedimentData.rouseP]);
+
+  const totalLoadData = [{ name: 'Q_s', value: sedimentData.totalLoad }];
+
+  return (
+    <>
+      <Widget id="bedloadCurve" title="Curva del bed-load">
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={bedloadData}>
+            <XAxis dataKey="theta" tickFormatter={(v) => v.toFixed(2)} />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="mpm" stroke="#8884d8" name="MPM" />
+            <Line
+              type="monotone"
+              dataKey="einstein"
+              stroke="#82ca9d"
+              name="Einstein"
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </Widget>
+      <Widget id="concentrationProfile" title="Profilo di concentrazione">
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={concentrationData}>
+            <XAxis dataKey="z" tickFormatter={(v) => v.toFixed(2)} />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="c" stroke="#ff7300" dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </Widget>
+      <Widget id="totalLoad" title="Carico totale">
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={totalLoadData}>
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="value" fill="#ffc658">
+              <LabelList dataKey="value" position="top" />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </Widget>
+    </>
+  );
+}
+
+SedimentGraphs.propTypes = {
+  params: PropTypes.shape({
+    d50: PropTypes.number.isRequired,
+    rhoS: PropTypes.number.isRequired,
+    h: PropTypes.number.isRequired
+  }).isRequired,
+  sedimentData: PropTypes.shape({
+    theta: PropTypes.number.isRequired,
+    rouseP: PropTypes.number.isRequired,
+    totalLoad: PropTypes.number.isRequired
+  }).isRequired
+};

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -97,6 +97,10 @@ export default function Sidebar({
                 <span className="w-4">{visibleCharts.evolutionTable ? '✓' : ''}</span>
                 Tabella evolutiva
               </button>
+              <button className="submenu-item w-full text-left flex items-center" onClick={() => toggleChart('sediments')}>
+                <span className="w-4">{visibleCharts.sediments ? '✓' : ''}</span>
+                Sedimenti
+              </button>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- create new `SedimentGraphs` component with bed-load, concentration and load graphs
- integrate component in `Graphs` widget map
- expose visibility control in sidebar
- include new widget in default state and pass parameters

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551f32ce30832fbe0a8352c81a9321