### PR TITLE
Add evolution variable widget

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -51,7 +51,7 @@ La pagina **Risultati** e i grafici mostrano i valori calcolati con queste formu
 ## Grafici disponibili
 
 - Radar delle efficienze.
-- Grafico evolutivo per Q o v.
+- Grafico evolutivo per q o v.
 - Tabella con gli stessi valori.
 - Curva del bed-load (MPM vs Einstein).
 - Profilo di concentrazione secondo Rouse.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
 - Parametri di trasporto solido (Shields, bed-load, profilo di Rouse, carico totale)
 
 - Visualizzazione su **grafico radar** dinamico.
-- Grafico evolutivo per Q o v su intervalli definiti.
-- Tabella dell'andamento per Q o v sugli stessi intervalli.
+- Grafico evolutivo per q o v su intervalli definiti.
+- Tabella dell'andamento per q o v sugli stessi intervalli.
 - Grafici sul trasporto solido (curva del bed-load, profilo di concentrazione e
   carico totale).
 - Modalità chiaro/scuro con pulsante di attivazione.

--- a/src/components/EvolutionTable.jsx
+++ b/src/components/EvolutionTable.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import './EvolutionTable.css';
 
 export default function EvolutionTable({ evolutionData, rangeVar }) {
-  const header = rangeVar === 'Q' ? 'Q (l/s)' : 'v (m/s)';
+  const header = rangeVar === 'v' ? 'v (m/s)' : 'q (l/s)';
 
   return (
     <table className="evolution-table">

--- a/src/components/ParameterControls.jsx
+++ b/src/components/ParameterControls.jsx
@@ -191,34 +191,36 @@ export default function ParameterControls({
         {renderSlider('E0')}
       </Widget>
 
-      <div className="range-selector">
-        <label>
-          Variabile:
-          <select
-            value={rangeVar}
-            onChange={(e) => setRangeVar(e.target.value)}
-          >
-            <option value="v">v</option>
-            <option value="Q">Q</option>
-          </select>
-        </label>
-        <label>
-          Min:
-          <input
-            type="number"
-            value={rangeMin}
-            onChange={(e) => setRangeMin(parseFloat(e.target.value))}
-          />
-        </label>
-        <label>
-          Max:
-          <input
-            type="number"
-            value={rangeMax}
-            onChange={(e) => setRangeMax(parseFloat(e.target.value))}
-          />
-        </label>
-      </div>
+      <Widget id="evolutivoVar" title="Evolutivo per variabile">
+        <div className="range-selector">
+          <label>
+            Variabile:
+            <select
+              value={rangeVar}
+              onChange={(e) => setRangeVar(e.target.value)}
+            >
+              <option value="v">v</option>
+              <option value="q">q</option>
+            </select>
+          </label>
+          <label>
+            Min:
+            <input
+              type="number"
+              value={rangeMin}
+              onChange={(e) => setRangeMin(parseFloat(e.target.value))}
+            />
+          </label>
+          <label>
+            Max:
+            <input
+              type="number"
+              value={rangeMax}
+              onChange={(e) => setRangeMax(parseFloat(e.target.value))}
+            />
+          </label>
+        </div>
+      </Widget>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the range selector in the Parameters page inside a new widget
- allow selecting variable `v` or `q`
- adjust evolution table header accordingly
- update documentation references to `q`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855245017d8832fbd22430192591ae5