### PR TITLE
Add MathJax formulas

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -6,7 +6,7 @@ Questa applicazione permette di calcolare l'efficienza idraulica delle caditoie 
 
 - Usa gli slider nella pagina **Parametri** per impostare i valori di input.
 - Passa alla pagina **Simulazione** per vedere i grafici.
-- Ogni grafico è contenuto in un *widget* che puoi:
+- Ogni grafico è contenuto in un _widget_ che puoi:
   - ridimensionare trascinando l'angolo in basso a destra;
   - trascinare per modificare l'ordine dei grafici;
   - minimizzare o espandere con il pulsante `➖`/`➕` nella barra del widget.
@@ -31,20 +31,20 @@ Questa applicazione permette di calcolare l'efficienza idraulica delle caditoie 
 
 ## Formule utilizzate
 
-- R1 = 1 - 0.3 (v - v0) → efficienza legata alla velocità del flusso.
-- R2 = 1 / (1 + (0.083 × v¹·⁸) / (j × L²⁄³)) → efficienza influenzata da pendenza e lunghezza della griglia.
-- Q1* = Q1 × R1 → portata intercettata dal tratto a monte.
-- Q2 = Q - Q1 → portata che non raggiunge direttamente la caditoia.
-- Q2* = Q2 × R2 → porzione intercettata di Q2.
-- E = (Q1* + Q2*) / Q → efficienza idraulica totale.
-- E formula = R1 × E0 + R2 × (1 - E0) → stima alternativa basata su E0.
-- θ = τ / ((ρ_s - ρ) g d) → parametro di Shields.
-- τ_c = θ_c (ρ_s - ρ) g d → tensione di inizio moto.
-- q_s^MPM = 8 √[g (s - 1) d³] (θ - θ_c)^{3/2} → bed-load Meyer‑Peter & Müller.
-- q_s^E = 0.4 √[g (s - 1) d³] (θ - θ_c)^{5/2} → bed-load Einstein.
-- P = w_s / (κ u_*) → esponente di Rouse.
-- C(z) = C_a [(h - z)/z · z_a/(h - z_a)]^P → profilo di concentrazione.
-- Q_s = 0.5 (0.05 θ^{2.5} + 0.016 θ^{2.1}) √[g (s - 1) d³] → carico totale.
+- \(R_1 = 1 - 0.3\,(v - v_0)\) → efficienza legata alla velocità del flusso.
+- \(R_2 = \frac{1}{1 + \frac{0.083\, v^{1.8}}{j\, L^{2/3}}}\) → efficienza influenzata da pendenza e lunghezza della griglia.
+- \(Q_1^\* = Q_1\, R_1\) → portata intercettata dal tratto a monte.
+- \(Q_2 = Q - Q_1\) → portata che non raggiunge direttamente la caditoia.
+- \(Q_2^\* = Q_2\, R_2\) → porzione intercettata di Q2.
+- \(E = \frac{Q_1^_ + Q_2^_}{Q}\) → efficienza idraulica totale.
+- \(E\_{\text{formula}} = R_1\, E_0 + R_2\,(1 - E_0)\) → stima alternativa basata su E0.
+- \(\theta = \frac{\tau}{(\rho_s - \rho)\, g\, d}\) → parametro di Shields.
+- \(\tau_c = \theta_c(\rho_s - \rho) g d\) → tensione di inizio moto.
+- \(q_s^{MPM} = 8\,\sqrt{g(s - 1) d^3}(\theta - \theta_c)^{3/2}\) → bed-load Meyer‑Peter & Müller.
+- \(q_s^{E} = 0.4\,\sqrt{g(s - 1) d^3}(\theta - \theta_c)^{5/2}\) → bed-load Einstein.
+- \(P = \frac{w*s}{\kappa u*\*}\) → esponente di Rouse.
+- \(C(z) = C_a \left[\frac{h - z}{z} \cdot \frac{z_a}{h - z_a}\right]^P\) → profilo di concentrazione.
+- \(Q_s = 0.5 (0.05\,\theta^{2.5} + 0.016\theta^{2.1}) \sqrt{g (s - 1) d^3}\) → carico totale.
 
 La pagina **Risultati** e i grafici mostrano i valori calcolati con queste formule.
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,17 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      window.MathJax = {
+        tex: { inlineMath: [['\\(', '\\)'], ['$', '$']] },
+        svg: { fontCache: 'global' }
+      };
+    </script>
+    <script
+      id="MathJax-script"
+      async
+      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"
+    ></script>
     <title>Efficienza Caditoie</title>
   </head>
   <body>

--- a/src/Formula.jsx
+++ b/src/Formula.jsx
@@ -1,0 +1,18 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+
+export default function Formula({ children }) {
+  const spanRef = useRef(null);
+
+  useEffect(() => {
+    if (window.MathJax && window.MathJax.typesetPromise) {
+      window.MathJax.typesetPromise([spanRef.current]);
+    }
+  }, [children]);
+
+  return <span ref={spanRef}>{children}</span>;
+}
+
+Formula.propTypes = {
+  children: PropTypes.string.isRequired
+};

--- a/src/Help.jsx
+++ b/src/Help.jsx
@@ -1,17 +1,19 @@
 import React from 'react';
+import Formula from './Formula';
 
 export default function Help() {
   return (
     <div className="p-4 space-y-2">
       <h1>Aiuto</h1>
       <p>
-        Questa applicazione permette di calcolare l'efficienza idraulica delle caditoie
-        stradali e visualizzarla tramite diversi grafici.
+        Questa applicazione permette di calcolare l'efficienza idraulica delle
+        caditoie stradali e visualizzarla tramite diversi grafici.
       </p>
       <h2>Come utilizzare l'interfaccia</h2>
       <ul className="list-disc pl-6 space-y-1">
         <li>
-          Usa gli slider nella pagina <strong>Parametri</strong> per impostare i valori di input.
+          Usa gli slider nella pagina <strong>Parametri</strong> per impostare i
+          valori di input.
         </li>
         <li>
           Passa alla pagina <strong>Simulazione</strong> per vedere i grafici.
@@ -20,18 +22,23 @@ export default function Help() {
         <ul className="list-disc pl-6">
           <li>ridimensionare trascinando l'angolo in basso a destra;</li>
           <li>trascinare per modificare l'ordine dei grafici;</li>
-          <li>minimizzare o espandere con il pulsante '➖'/'➕' nella barra del widget.</li>
+          <li>
+            minimizzare o espandere con il pulsante '➖'/'➕' nella barra del
+            widget.
+          </li>
         </ul>
         <li>
-          Nella sidebar puoi attivare o disattivare i singoli grafici dalla sezione
+          Nella sidebar puoi attivare o disattivare i singoli grafici dalla
+          sezione
           <strong> Aspetto</strong>.
         </li>
         <li>
-          Le voci della sezione <strong>Azioni</strong> permettono di esportare i dati o
-          salvare/caricare i parametri.
+          Le voci della sezione <strong>Azioni</strong> permettono di esportare
+          i dati o salvare/caricare i parametri.
         </li>
         <li>
-          Usa il pulsante nella parte alta destra della sidebar per aprirla o chiuderla.
+          Usa il pulsante nella parte alta destra della sidebar per aprirla o
+          chiuderla.
         </li>
       </ul>
       <h2>Parametri</h2>
@@ -71,23 +78,82 @@ export default function Help() {
       </ul>
       <h2>Formule utilizzate</h2>
       <ul className="list-disc pl-6 space-y-1">
-        <li>R1 = 1 - 0.3 (v - v0) → efficienza legata alla velocità del flusso.</li>
         <li>
-          R2 = 1 / (1 + (0.083 × v¹¸) / (j × L²⁄³)) → efficienza influenzata
-          da pendenza e lunghezza della griglia.
+          <Formula>{'\\(R_1 = 1 - 0.3\,(v - v_0)\\)'}</Formula> → efficienza
+          legata alla velocità del flusso.
         </li>
-        <li>Q1* = Q1 × R1 → portata intercettata dal tratto a monte.</li>
-        <li>Q2 = Q - Q1 → portata che non raggiunge direttamente la caditoia.</li>
-        <li>Q2* = Q2 × R2 → porzione intercettata di Q2.</li>
-        <li>E = (Q1* + Q2*) / Q → efficienza idraulica totale.</li>
-        <li>E formula = R1 × E0 + R2 × (1 - E0) → stima alternativa basata su E0.</li>
-        <li>θ = τ / ((ρ_s - ρ) g d) → parametro di Shields.</li>
-        <li>τ_c = θ_c (ρ_s - ρ) g d → tensione di inizio moto.</li>
-        <li>q_s^MPM = 8 √[g (s - 1) d³] (θ - θ_c)<sup>3/2</sup> → bed-load Meyer‑Peter & Müller.</li>
-        <li>q_s^E = 0.4 √[g (s - 1) d³] (θ - θ_c)<sup>5/2</sup> → bed-load Einstein.</li>
-        <li>P = w_s / (κ u_*) → esponente di Rouse.</li>
-        <li>C(z) = C_a [(h - z)/z · z_a/(h - z_a)]^P → profilo di concentrazione.</li>
-        <li>Q_s = 0.5 (0.05 θ^{2.5} + 0.016 θ^{2.1}) √[g (s - 1) d³] → carico totale.</li>
+        <li>
+          <Formula>
+            {
+              '\\(R_2 = \\frac{1}{1 + \\frac{0.083\\, v^{1.8}}{j\\, L^{2/3}}}\\)'
+            }
+          </Formula>
+          → efficienza influenzata da pendenza e lunghezza della griglia.
+        </li>
+        <li>
+          <Formula>{'\\(Q_1^* = Q_1\\, R_1\\)'}</Formula> → portata intercettata
+          dal tratto a monte.
+        </li>
+        <li>
+          <Formula>{'\\(Q_2 = Q - Q_1\\)'}</Formula> → portata che non raggiunge
+          direttamente la caditoia.
+        </li>
+        <li>
+          <Formula>{'\\(Q_2^* = Q_2\\, R_2\\)'}</Formula> → porzione
+          intercettata di Q2.
+        </li>
+        <li>
+          <Formula>{'\\(E = \\frac{Q_1^* + Q_2^*}{Q}\\)'}</Formula> → efficienza
+          idraulica totale.
+        </li>
+        <li>
+          <Formula>
+            {'\\(E_{\\text{formula}} = R_1\\, E_0 + R_2\\,(1 - E_0)\\)'}
+          </Formula>
+          → stima alternativa basata su E0.
+        </li>
+        <li>
+          <Formula>
+            {'\\(\\theta = \\frac{\\tau}{(\\rho_s - \\rho)\\, g\\, d}\\)'}
+          </Formula>
+          → parametro di Shields.
+        </li>
+        <li>
+          <Formula>{'\\(\\tau_c = \\theta_c(\\rho_s - \\rho) g d\\)'}</Formula>{' '}
+          → tensione di inizio moto.
+        </li>
+        <li>
+          <Formula>
+            {'\\(q_s^{MPM} = 8\\,\\sqrt{g(s-1)d^3}(\\theta-\\theta_c)^{3/2}\\)'}
+          </Formula>
+          → bed-load Meyer‑Peter & Müller.
+        </li>
+        <li>
+          <Formula>
+            {'\\(q_s^{E} = 0.4\\,\\sqrt{g(s-1)d^3}(\\theta-\\theta_c)^{5/2}\\)'}
+          </Formula>
+          → bed-load Einstein.
+        </li>
+        <li>
+          <Formula>{'\\(P = \\frac{w_s}{\\kappa u_*}\\)'}</Formula> → esponente
+          di Rouse.
+        </li>
+        <li>
+          <Formula>
+            {
+              '\\(C(z) = C_a \\left[\frac{h - z}{z} \\cdot \frac{z_a}{h - z_a}\\right]^P\\)'
+            }
+          </Formula>
+          → profilo di concentrazione.
+        </li>
+        <li>
+          <Formula>
+            {
+              '\\(Q_s = 0.5 (0.05\\,\\theta^{2.5} + 0.016\\theta^{2.1})\\,\\sqrt{g (s - 1) d^3}\\)'
+            }
+          </Formula>
+          → carico totale.
+        </li>
       </ul>
       <p>
         La pagina <strong>Risultati</strong> e i grafici mostrano i valori

--- a/src/components/Graphs.jsx
+++ b/src/components/Graphs.jsx
@@ -17,11 +17,12 @@ import {
   Cell,
   LineChart,
   Line,
-  LabelList,
+  LabelList
 } from 'recharts';
 import Widget from '../Widget';
 import EvolutionTable from './EvolutionTable';
 import SedimentGraphs from './SedimentGraphs';
+import Formula from '../Formula';
 
 export default function Graphs({
   R1,
@@ -48,7 +49,7 @@ export default function Graphs({
   pieRef,
   lineRef,
   evolutionRef,
-  resultsRef,
+  resultsRef
 }) {
   const widgetMap = {
     results: (
@@ -60,31 +61,47 @@ export default function Graphs({
         onDrop={handleDrop}
       >
         <div className="formula-list">
-          <p>R1 = 1 - 0.3 (v - v0) = {R1.toFixed(2)}</p>
           <p>
-            R2 = 1 / (1 + (0.083 * v<sup>1.8</sup>) / (j * L<sup>2/3</sup>)) =
-            {R2.toFixed(2)}
-          </p>
-          <p>Q1* = Q1 × R1 = {Q1_star.toFixed(2)}</p>
-          <p>Q2 = Q - Q1 = {Q2.toFixed(2)}</p>
-          <p>Q2* = Q2 × R2 = {Q2_star.toFixed(2)}</p>
-          <p>E = (Q1* + Q2*) / Q = {E.toFixed(2)}</p>
-          <p>E formula = R1 × E0 + R2 × (1 - E0) = {E_formula.toFixed(2)}</p>
-          <p>τ = ρ g h j = {sedimentData.tau.toFixed(2)}</p>
-          <p>θ = τ / ((ρ_s - ρ) g d) = {sedimentData.theta.toFixed(2)}</p>
-          <p>τ_c = θ_c (ρ_s - ρ) g d = {sedimentData.tauC.toFixed(2)}</p>
-          <p>
-            q_s^MPM = 8 √[g(s - 1) d³] (θ - θ_c)<sup>3/2</sup> ={' '}
-            {sedimentData.bedloadMPM.toExponential(2)}
+            <Formula>{`\\(R_1 = 1 - 0.3\,(v - v_0) = ${R1.toFixed(2)}\\)`}</Formula>
           </p>
           <p>
-            q_s^E = 0.4 √[g(s - 1) d³] (θ - θ_c)<sup>5/2</sup> ={' '}
-            {sedimentData.bedloadEinstein.toExponential(2)}
+            <Formula>{`\\(R_2 = \\frac{1}{1 + \\frac{0.083\\, v^{1.8}}{j\\, L^{2/3}}} = ${R2.toFixed(2)}\\)`}</Formula>
           </p>
-          <p>P = w_s / (κ u_*) = {sedimentData.rouseP.toFixed(2)}</p>
           <p>
-            Q_s = 0.5(0.05 θ^{2.5} + 0.016 θ^{2.1}) √[g(s - 1) d³] ={' '}
-            {sedimentData.totalLoad.toExponential(2)}
+            <Formula>{`\\(Q_1^* = Q_1\\, R_1 = ${Q1_star.toFixed(2)}\\)`}</Formula>
+          </p>
+          <p>
+            <Formula>{`\\(Q_2 = Q - Q_1 = ${Q2.toFixed(2)}\\)`}</Formula>
+          </p>
+          <p>
+            <Formula>{`\\(Q_2^* = Q_2\\, R_2 = ${Q2_star.toFixed(2)}\\)`}</Formula>
+          </p>
+          <p>
+            <Formula>{`\\(E = \\frac{Q_1^* + Q_2^*}{Q} = ${E.toFixed(2)}\\)`}</Formula>
+          </p>
+          <p>
+            <Formula>{`\\(E_{\\text{formula}} = R_1\\, E_0 + R_2\\,(1 - E_0) = ${E_formula.toFixed(2)}\\)`}</Formula>
+          </p>
+          <p>
+            <Formula>{`\\(\\tau = \\rho\\, g\\, h\\, j = ${sedimentData.tau.toFixed(2)}\\)`}</Formula>
+          </p>
+          <p>
+            <Formula>{`\\(\\theta = \\frac{\\tau}{(\\rho_s - \\rho)\\, g\\, d} = ${sedimentData.theta.toFixed(2)}\\)`}</Formula>
+          </p>
+          <p>
+            <Formula>{`\\(\\tau_c = \\theta_c(\\rho_s - \\rho) g d = ${sedimentData.tauC.toFixed(2)}\\)`}</Formula>
+          </p>
+          <p>
+            <Formula>{`\\(q_s^{MPM} = 8\\,\\sqrt{g(s-1)d^3}(\\theta-\\theta_c)^{3/2} = ${sedimentData.bedloadMPM.toExponential(2)}\\)`}</Formula>
+          </p>
+          <p>
+            <Formula>{`\\(q_s^{E} = 0.4\\,\\sqrt{g(s-1)d^3}(\\theta-\\theta_c)^{5/2} = ${sedimentData.bedloadEinstein.toExponential(2)}\\)`}</Formula>
+          </p>
+          <p>
+            <Formula>{`\\(P = \\frac{w_s}{\\kappa u_*} = ${sedimentData.rouseP.toFixed(2)}\\)`}</Formula>
+          </p>
+          <p>
+            <Formula>{`\\(Q_s = 0.5(0.05\\,\\theta^{2.5} + 0.016\\theta^{2.1})\\,\\sqrt{g(s-1)d^3} = ${sedimentData.totalLoad.toExponential(2)}\\)`}</Formula>
           </p>
         </div>
       </Widget>
@@ -130,7 +147,11 @@ export default function Graphs({
             <YAxis domain={[0, 1]} />
             <Tooltip />
             <Bar dataKey="value" fill="#82ca9d">
-              <LabelList dataKey="value" position="top" formatter={(v) => v.toFixed(2)} />
+              <LabelList
+                dataKey="value"
+                position="top"
+                formatter={(v) => v.toFixed(2)}
+              />
             </Bar>
           </BarChart>
         </ResponsiveContainer>
@@ -176,7 +197,11 @@ export default function Graphs({
             <YAxis domain={[0, 1]} />
             <Tooltip />
             <Line type="monotone" dataKey="value" stroke="#8884d8">
-              <LabelList dataKey="value" position="top" formatter={(v) => v.toFixed(2)} />
+              <LabelList
+                dataKey="value"
+                position="top"
+                formatter={(v) => v.toFixed(2)}
+              />
             </Line>
           </LineChart>
         </ResponsiveContainer>
@@ -196,7 +221,11 @@ export default function Graphs({
             <YAxis domain={[0, 1]} />
             <Tooltip />
             <Line type="monotone" dataKey="efficiency" stroke="#ff7300">
-              <LabelList dataKey="efficiency" position="top" formatter={(v) => v.toFixed(2)} />
+              <LabelList
+                dataKey="efficiency"
+                position="top"
+                formatter={(v) => v.toFixed(2)}
+              />
             </Line>
           </LineChart>
         </ResponsiveContainer>
@@ -212,10 +241,12 @@ export default function Graphs({
         <EvolutionTable evolutionData={evolutionData} rangeVar={rangeVar} />
       </Widget>
     ),
-    sediments: <SedimentGraphs params={params} sedimentData={sedimentData} />,
+    sediments: <SedimentGraphs params={params} sedimentData={sedimentData} />
   };
 
-  return <>{widgetOrder.map((w) => (visibleCharts[w] ? widgetMap[w] : null))}</>;
+  return (
+    <>{widgetOrder.map((w) => (visibleCharts[w] ? widgetMap[w] : null))}</>
+  );
 }
 
 Graphs.propTypes = {
@@ -243,5 +274,5 @@ Graphs.propTypes = {
   pieRef: PropTypes.object,
   lineRef: PropTypes.object,
   evolutionRef: PropTypes.object,
-  resultsRef: PropTypes.object,
+  resultsRef: PropTypes.object
 };


### PR DESCRIPTION
## Summary
- render formulas with MathJax on the results widget and help page
- add a small `Formula` component
- load MathJax from CDN

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685525ad86f0832fa4d22f45c524cb14