### PR TITLE
Fix range variable for Q evolution chart

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -51,7 +51,7 @@ La pagina **Risultati** e i grafici mostrano i valori calcolati con queste formu
 ## Grafici disponibili
 
 - Radar delle efficienze.
-- Grafico evolutivo per q o v.
+- Grafico evolutivo per Q o v.
 - Tabella con gli stessi valori.
 - Curva del bed-load (MPM vs Einstein).
 - Profilo di concentrazione secondo Rouse.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
 - Parametri di trasporto solido (Shields, bed-load, profilo di Rouse, carico totale)
 
 - Visualizzazione su **grafico radar** dinamico.
-- Grafico evolutivo per q o v su intervalli definiti.
-- Tabella dell'andamento per q o v sugli stessi intervalli.
+- Grafico evolutivo per Q o v su intervalli definiti.
+- Tabella dell'andamento per Q o v sugli stessi intervalli.
 - Grafici sul trasporto solido (curva del bed-load, profilo di concentrazione e
   carico totale).
 - Modalità chiaro/scuro con pulsante di attivazione.

--- a/src/components/EvolutionTable.jsx
+++ b/src/components/EvolutionTable.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import './EvolutionTable.css';
 
 export default function EvolutionTable({ evolutionData, rangeVar }) {
-  const header = rangeVar === 'v' ? 'v (m/s)' : 'q (l/s)';
+  const header = rangeVar === 'v' ? 'v (m/s)' : 'Q (l/s)';
 
   return (
     <table className="evolution-table">

--- a/src/components/ParameterControls.jsx
+++ b/src/components/ParameterControls.jsx
@@ -200,7 +200,7 @@ export default function ParameterControls({
               onChange={(e) => setRangeVar(e.target.value)}
             >
               <option value="v">v</option>
-              <option value="q">q</option>
+              <option value="Q">Q</option>
             </select>
           </label>
           <label>


### PR DESCRIPTION
## Summary
- use `Q` instead of lowercase `q` when choosing the variable for the evolution chart
- update evolution table header
- adjust docs accordingly

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855284db4d8832f9632856ecd1350c4