### PR TITLE
Switch MathJax output to CHTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,13 @@
     <script>
       window.MathJax = {
         tex: { inlineMath: [['\\(', '\\)'], ['$', '$']] },
-        svg: { fontCache: 'global' }
+        chtml: { scale: 1 }
       };
     </script>
     <script
       id="MathJax-script"
       async
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"
+      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"
     ></script>
     <title>Efficienza Caditoie</title>
   </head>


### PR DESCRIPTION
## Summary
- use CommonHTML output for MathJax

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68552bbe40cc832fa2cc9c8fa193aff3