### PR TITLE
Fix API key input size

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -294,6 +294,11 @@ body.dark-mode {
   margin-top: 8px;
 }
 
+/* Ensure the full API key is visible */
+.api-key-input input {
+  width: 280px;
+}
+
 .password-wrapper {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- widen the OpenWeather API key input so it's easier to verify key contents

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68553c4bcee4832f87bd31819f56fb5e