### PR TITLE
Add dry deposition modeling widget

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -303,3 +303,9 @@ body.dark-mode {
   cursor: pointer;
   user-select: none;
 }
+
+.dry-inputs {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -182,6 +182,8 @@ export default function App() {
     totalLoad: 0,
     rouseP: 0,
   });
+  const [dryDays, setDryDays] = useState(0);
+  const [zoneType, setZoneType] = useState('residenziale');
   const [visibleCharts, setVisibleCharts] = useState({
     radar: true,
     bar: true,
@@ -191,6 +193,7 @@ export default function App() {
     evolutionTable: true,
     results: true,
     sediments: true,
+    accumulation: true,
   });
   const [widgetOrder, setWidgetOrder] = useState([
     'results',
@@ -201,6 +204,7 @@ export default function App() {
     'evolution',
     'evolutionTable',
     'sediments',
+    'accumulation',
   ]);
   const [dragging, setDragging] = useState(null);
   const [appearanceOpen, setAppearanceOpen] = useState(false);
@@ -478,6 +482,10 @@ export default function App() {
             widgetOrder={widgetOrder}
             handleDragStart={handleDragStart}
             handleDrop={handleDrop}
+            dryDays={dryDays}
+            setDryDays={setDryDays}
+            zoneType={zoneType}
+            setZoneType={setZoneType}
             radarRef={radarRef}
             barRef={barRef}
             pieRef={pieRef}

--- a/src/__tests__/accumulation.test.js
+++ b/src/__tests__/accumulation.test.js
@@ -1,0 +1,18 @@
+import { linearAccumulation, saturatingAccumulation, getZoneDefaults } from '../utils/accumulation';
+
+describe('dry accumulation utilities', () => {
+  test('linear accumulation', () => {
+    expect(linearAccumulation(5, 0.4)).toBeCloseTo(2);
+  });
+
+  test('saturating accumulation', () => {
+    const val = saturatingAccumulation(5, 0.5, 10);
+    expect(val).toBeCloseTo(10 * (1 - Math.exp(-2.5)), 5);
+  });
+
+  test('zone defaults', () => {
+    const { k, Lmax } = getZoneDefaults('industriale');
+    expect(k).toBeCloseTo(1.5);
+    expect(Lmax).toBeCloseTo(15);
+  });
+});

--- a/src/__tests__/dryAccumulation.test.jsx
+++ b/src/__tests__/dryAccumulation.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DryAccumulation from '../components/DryAccumulation';
+
+describe('DryAccumulation component', () => {
+  test('renders inputs and results', () => {
+    render(
+      <DryAccumulation
+        days={5}
+        setDays={() => {}}
+        zone="residenziale"
+        setZone={() => {}}
+      />
+    );
+    expect(screen.getByText('Accumulo secco')).toBeInTheDocument();
+    expect(screen.getByText(/Carico lineare/)).toBeInTheDocument();
+    expect(screen.getByText(/Carico con saturazione/)).toBeInTheDocument();
+  });
+});

--- a/src/components/DryAccumulation.jsx
+++ b/src/components/DryAccumulation.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Widget from '../Widget';
+import {
+  linearAccumulation,
+  saturatingAccumulation,
+  getZoneDefaults
+} from '../utils/accumulation';
+
+export default function DryAccumulation({ days, setDays, zone, setZone }) {
+  const defaults = getZoneDefaults(zone);
+  const linear = linearAccumulation(days, defaults.k);
+  const saturating = saturatingAccumulation(days, defaults.k, defaults.Lmax);
+
+  return (
+    <Widget id="dry" title="Accumulo secco">
+      <div className="dry-inputs">
+        <label>
+          Zona:
+          <select value={zone} onChange={(e) => setZone(e.target.value)}>
+            <option value="residenziale">Residenziale</option>
+            <option value="commerciale">Commerciale</option>
+            <option value="industriale">Industriale</option>
+          </select>
+        </label>
+        <label>
+          Giorni senza pioggia:
+          <input
+            type="number"
+            value={days}
+            min={0}
+            onChange={(e) => setDays(parseFloat(e.target.value))}
+          />
+        </label>
+      </div>
+      <div className="dry-results">
+        <p>Carico lineare: {linear.toFixed(2)} kg/ha</p>
+        <p>Carico con saturazione: {saturating.toFixed(2)} kg/ha</p>
+      </div>
+    </Widget>
+  );
+}
+
+DryAccumulation.propTypes = {
+  days: PropTypes.number.isRequired,
+  setDays: PropTypes.func.isRequired,
+  zone: PropTypes.string.isRequired,
+  setZone: PropTypes.func.isRequired
+};

--- a/src/components/Graphs.jsx
+++ b/src/components/Graphs.jsx
@@ -22,6 +22,7 @@ import {
 import Widget from '../Widget';
 import EvolutionTable from './EvolutionTable';
 import SedimentGraphs from './SedimentGraphs';
+import DryAccumulation from './DryAccumulation';
 import Formula from '../Formula';
 
 function Graphs({
@@ -44,6 +45,10 @@ function Graphs({
   widgetOrder,
   handleDragStart,
   handleDrop,
+  dryDays,
+  setDryDays,
+  zoneType,
+  setZoneType,
   radarRef,
   barRef,
   pieRef,
@@ -241,7 +246,15 @@ function Graphs({
         <EvolutionTable evolutionData={evolutionData} rangeVar={rangeVar} />
       </Widget>
     ),
-    sediments: <SedimentGraphs params={params} sedimentData={sedimentData} />
+    sediments: <SedimentGraphs params={params} sedimentData={sedimentData} />,
+    accumulation: (
+      <DryAccumulation
+        days={dryDays}
+        setDays={setDryDays}
+        zone={zoneType}
+        setZone={setZoneType}
+      />
+    )
   };
 
   return (
@@ -269,6 +282,10 @@ Graphs.propTypes = {
   widgetOrder: PropTypes.array.isRequired,
   handleDragStart: PropTypes.func.isRequired,
   handleDrop: PropTypes.func.isRequired,
+  dryDays: PropTypes.number.isRequired,
+  setDryDays: PropTypes.func.isRequired,
+  zoneType: PropTypes.string.isRequired,
+  setZoneType: PropTypes.func.isRequired,
   radarRef: PropTypes.object,
   barRef: PropTypes.object,
   pieRef: PropTypes.object,

--- a/src/utils/accumulation.js
+++ b/src/utils/accumulation.js
@@ -1,0 +1,17 @@
+export function linearAccumulation(days, k, L0 = 0) {
+  return L0 + k * days;
+}
+
+export function saturatingAccumulation(days, k, Lmax) {
+  return Lmax * (1 - Math.exp(-k * days));
+}
+
+const zoneDefaults = {
+  residenziale: { k: 0.35, Lmax: 4 },
+  commerciale: { k: 0.75, Lmax: 7.5 },
+  industriale: { k: 1.5, Lmax: 15 }
+};
+
+export function getZoneDefaults(zone) {
+  return zoneDefaults[zone] || zoneDefaults.residenziale;
+}


### PR DESCRIPTION
## Summary
- implement linear and saturation accumulation utilities
- provide DryAccumulation React widget to estimate dry load
- integrate new widget into the graphs page
- track zone type and dry days in state
- tests for accumulation utilities and component
- basic styling for the widget

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685551cece64832f9d577115d08e0a17