### PR TITLE
Add configurable accumulation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
   - Granulometria media (d50)
   - Densità dei sedimenti (rhoS)
   - Profondità idraulica (h)
+  - Parametri di accumulo secco per zona (k e Lmax)
+
+    | Ambiente urbano | k tipico (kg/ha/giorno) | Lmax (kg/ha) |
+    | --------------- | ----------------------- | ------------ |
+    | Residenziale    | 0.2 – 0.5               | 3 – 5        |
+    | Commerciale     | 0.5 – 1.0               | 5 – 10       |
+    | Industriale     | 1.0 – 2.0               | 10 – 20      |
 
 - Calcolo automatico di:
   - Efficienza R1

--- a/src/App.css
+++ b/src/App.css
@@ -54,7 +54,6 @@ body.dark-mode {
   background: #ddd;
 }
 
-
 .sidebar-toggle {
   background: #007bff;
   color: #fff;
@@ -308,4 +307,16 @@ body.dark-mode {
   display: flex;
   gap: 10px;
   margin-bottom: 10px;
+}
+
+.zone-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.zone-table th,
+.zone-table td {
+  border: 1px solid #ccc;
+  padding: 4px;
+  text-align: center;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import ParameterControls from "./components/ParameterControls";
 import Graphs from "./components/Graphs";
 import Sidebar from "./components/Sidebar";
 import { fetchRain, verifyApiKey } from "./utils/weather";
+import { zoneDefaults } from "./utils/accumulation";
 import {
   shieldsParameter,
   criticalShearStress,
@@ -184,6 +185,7 @@ export default function App() {
   });
   const [dryDays, setDryDays] = useState(0);
   const [zoneType, setZoneType] = useState('residenziale');
+  const [zoneParams, setZoneParams] = useState(zoneDefaults);
   const [visibleCharts, setVisibleCharts] = useState({
     radar: true,
     bar: true,
@@ -459,6 +461,8 @@ export default function App() {
             apiVerified={apiVerified}
             verifyKey={verifyKey}
             rain={rain}
+            zoneParams={zoneParams}
+            setZoneParams={setZoneParams}
           />
         )}
         {activePage === 'graphs' && (
@@ -486,6 +490,7 @@ export default function App() {
             setDryDays={setDryDays}
             zoneType={zoneType}
             setZoneType={setZoneType}
+            zoneParams={zoneParams}
             radarRef={radarRef}
             barRef={barRef}
             pieRef={pieRef}

--- a/src/components/DryAccumulation.jsx
+++ b/src/components/DryAccumulation.jsx
@@ -7,8 +7,14 @@ import {
   getZoneDefaults
 } from '../utils/accumulation';
 
-export default function DryAccumulation({ days, setDays, zone, setZone }) {
-  const defaults = getZoneDefaults(zone);
+export default function DryAccumulation({
+  days,
+  setDays,
+  zone,
+  setZone,
+  zoneParams
+}) {
+  const defaults = getZoneDefaults(zone, zoneParams);
   const linear = linearAccumulation(days, defaults.k);
   const saturating = saturatingAccumulation(days, defaults.k, defaults.Lmax);
 
@@ -45,5 +51,6 @@ DryAccumulation.propTypes = {
   days: PropTypes.number.isRequired,
   setDays: PropTypes.func.isRequired,
   zone: PropTypes.string.isRequired,
-  setZone: PropTypes.func.isRequired
+  setZone: PropTypes.func.isRequired,
+  zoneParams: PropTypes.object
 };

--- a/src/components/Graphs.jsx
+++ b/src/components/Graphs.jsx
@@ -49,6 +49,7 @@ function Graphs({
   setDryDays,
   zoneType,
   setZoneType,
+  zoneParams,
   radarRef,
   barRef,
   pieRef,
@@ -253,6 +254,7 @@ function Graphs({
         setDays={setDryDays}
         zone={zoneType}
         setZone={setZoneType}
+        zoneParams={zoneParams}
       />
     )
   };
@@ -286,6 +288,7 @@ Graphs.propTypes = {
   setDryDays: PropTypes.func.isRequired,
   zoneType: PropTypes.string.isRequired,
   setZoneType: PropTypes.func.isRequired,
+  zoneParams: PropTypes.object.isRequired,
   radarRef: PropTypes.object,
   barRef: PropTypes.object,
   pieRef: PropTypes.object,

--- a/src/components/ParameterControls.jsx
+++ b/src/components/ParameterControls.jsx
@@ -47,7 +47,9 @@ function ParameterControls({
   setApiKey,
   apiVerified,
   verifyKey,
-  rain
+  rain,
+  zoneParams,
+  setZoneParams
 }) {
   const [showKey, setShowKey] = useState(false);
 
@@ -205,6 +207,51 @@ function ParameterControls({
           </label>
         </div>
       </Widget>
+
+      <Widget id="zoneParams" title="Parametri zona">
+        <table className="zone-table">
+          <thead>
+            <tr>
+              <th>Zona</th>
+              <th>k (kg/ha/giorno)</th>
+              <th>Lmax (kg/ha)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(zoneParams).map(([z, vals]) => (
+              <tr key={z}>
+                <td>{z}</td>
+                <td>
+                  <input
+                    type="number"
+                    value={vals.k}
+                    step="0.01"
+                    onChange={(e) =>
+                      setZoneParams((p) => ({
+                        ...p,
+                        [z]: { ...p[z], k: parseFloat(e.target.value) }
+                      }))
+                    }
+                  />
+                </td>
+                <td>
+                  <input
+                    type="number"
+                    value={vals.Lmax}
+                    step="0.1"
+                    onChange={(e) =>
+                      setZoneParams((p) => ({
+                        ...p,
+                        [z]: { ...p[z], Lmax: parseFloat(e.target.value) }
+                      }))
+                    }
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Widget>
     </>
   );
 }
@@ -239,7 +286,9 @@ ParameterControls.propTypes = {
   setApiKey: PropTypes.func.isRequired,
   apiVerified: PropTypes.bool.isRequired,
   verifyKey: PropTypes.func.isRequired,
-  rain: PropTypes.number
+  rain: PropTypes.number,
+  zoneParams: PropTypes.object.isRequired,
+  setZoneParams: PropTypes.func.isRequired
 };
 
 export default React.memo(ParameterControls);

--- a/src/utils/accumulation.js
+++ b/src/utils/accumulation.js
@@ -6,12 +6,12 @@ export function saturatingAccumulation(days, k, Lmax) {
   return Lmax * (1 - Math.exp(-k * days));
 }
 
-const zoneDefaults = {
+export const zoneDefaults = {
   residenziale: { k: 0.35, Lmax: 4 },
   commerciale: { k: 0.75, Lmax: 7.5 },
   industriale: { k: 1.5, Lmax: 15 }
 };
 
-export function getZoneDefaults(zone) {
-  return zoneDefaults[zone] || zoneDefaults.residenziale;
+export function getZoneDefaults(zone, defaults = zoneDefaults) {
+  return defaults[zone] || defaults.residenziale;
 }


### PR DESCRIPTION
## Summary
- allow passing zone parameters to dry accumulation component
- expose configurable table in parameter controls
- keep defaults in accumulation utility
- document defaults in README
- style table

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685553c7842c832f9a23554b862a74cb