### PR TITLE
Add g/m² display for dry accumulation

### DIFF
--- a/src/__tests__/dryAccumulation.test.jsx
+++ b/src/__tests__/dryAccumulation.test.jsx
@@ -14,6 +14,7 @@ describe('DryAccumulation component', () => {
     );
     expect(screen.getByText('Accumulo secco')).toBeInTheDocument();
     expect(screen.getByText(/Carico lineare/)).toBeInTheDocument();
+    expect(screen.getByText(/g\/m²/)).toBeInTheDocument();
     expect(screen.getByText(/Carico con saturazione/)).toBeInTheDocument();
   });
 });

--- a/src/components/DryAccumulation.jsx
+++ b/src/components/DryAccumulation.jsx
@@ -17,6 +17,8 @@ export default function DryAccumulation({
   const defaults = getZoneDefaults(zone, zoneParams);
   const linear = linearAccumulation(days, defaults.k);
   const saturating = saturatingAccumulation(days, defaults.k, defaults.Lmax);
+  const linearGm2 = linear * 0.1; // 1 kg/ha = 0.1 g/m²
+  const saturatingGm2 = saturating * 0.1;
 
   return (
     <Widget id="dry" title="Accumulo secco">
@@ -40,8 +42,13 @@ export default function DryAccumulation({
         </label>
       </div>
       <div className="dry-results">
-        <p>Carico lineare: {linear.toFixed(2)} kg/ha</p>
-        <p>Carico con saturazione: {saturating.toFixed(2)} kg/ha</p>
+        <p>
+          Carico lineare: {linear.toFixed(2)} kg/ha ({linearGm2.toFixed(2)} g/m²)
+        </p>
+        <p>
+          Carico con saturazione: {saturating.toFixed(2)} kg/ha (
+          {saturatingGm2.toFixed(2)} g/m²)
+        </p>
       </div>
     </Widget>
   );


### PR DESCRIPTION
## Summary
- show dry accumulation both in kg/ha and g/m²
- test for presence of new unit label

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555b8cdea8832f807d7903e3836b78