### PR TITLE
Fix repeated location not found error

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -130,12 +130,15 @@ export default function App() {
 
   useEffect(() => {
     if (dataSource === 'openweather' && apiVerified && city) {
-      fetchRain(city, apiKey)
-        .then((r) => {
-          setRain(r);
-          setParams((p) => ({ ...p, Q: r, Q1: r * 0.6 }));
-        })
-        .catch(() => addToast('Errore caricamento dati meteo'));
+      const handle = setTimeout(() => {
+        fetchRain(city, apiKey)
+          .then((r) => {
+            setRain(r);
+            setParams((p) => ({ ...p, Q: r, Q1: r * 0.6 }));
+          })
+          .catch((err) => addToast(err.message));
+      }, 500);
+      return () => clearTimeout(handle);
     }
   }, [dataSource, apiVerified, city, apiKey, addToast]);
 

--- a/src/utils/weather.js
+++ b/src/utils/weather.js
@@ -1,6 +1,9 @@
 export async function fetchRain(city, apiKey) {
   const url = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&appid=${apiKey}&units=metric`;
   const res = await fetch(url);
+  if (res.status === 404) {
+    throw new Error('Località non trovata');
+  }
   if (!res.ok) {
     throw new Error('Errore richiesta OpenWeatherMap');
   }


### PR DESCRIPTION
## Summary
- debounce OpenWeatherMap calls while typing the city
- show a clearer error when the city is invalid

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685922c0ad2c832fac7c48bc25e8f5ad