### PR TITLE
Add hydro-sediment impact chart

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -69,6 +69,7 @@ La pagina **Risultati** e i grafici mostrano i valori calcolati con queste formu
 - Curva del bed-load (MPM vs Einstein).
 - Profilo di concentrazione secondo Rouse.
 - Bar chart del carico totale.
+- Grafico d'impatto del bilancio idrologico sui sedimenti.
 
 ## Widget Bilancio idrologico
 
@@ -79,5 +80,8 @@ Il grafico "Bilancio idrologico" mostra l'andamento di:
 
 Questi valori si aggiornano modificando gli slider di radiazione solare,
 temperature minima e massima e Curve Number nella pagina **Parametri**.
+Il widget "Impatto bilancio-sedimenti" confronta il trasporto solido calcolato
+con la granulometria nominale e con quella effettiva *D_eff* derivata dal
+bilancio idrologico.
 
 Per ulteriori dettagli consulta il file `README.md`.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Per una guida rapida all'interfaccia è disponibile il file [HELP.md](HELP.md) o
 - Visualizzazione su **grafico radar** dinamico.
 - Grafico evolutivo per Q o v su intervalli definiti.
 - Tabella dell'andamento per Q o v sugli stessi intervalli.
-- Grafici sul trasporto solido (curva del bed-load, profilo di concentrazione e
-  carico totale).
+ - Grafici sul trasporto solido (curva del bed-load, profilo di concentrazione,
+  carico totale e impatto del bilancio idrologico sui sedimenti).
 - Modalità chiaro/scuro con pulsante di attivazione.
 - Layout responsive con possibilità di ridimensionare i pannelli.
 - Widget grafici minimizzabili, spostabili e ridimensionabili (incluso il nuovo widget "Bilancio idrologico").

--- a/src/__tests__/sedimentGraphs.test.jsx
+++ b/src/__tests__/sedimentGraphs.test.jsx
@@ -6,9 +6,17 @@ describe('SedimentGraphs component', () => {
   test('renders all graph widgets', () => {
     const params = { d50: 0.002, rhoS: 2650, h: 1 };
     const sedimentData = { theta: 0.1, rouseP: 0.5, totalLoad: 0.000001 };
-    render(<SedimentGraphs params={params} sedimentData={sedimentData} />);
+    const hydroData = [{ dEff: 0.0022 }];
+    render(
+      <SedimentGraphs
+        params={params}
+        sedimentData={sedimentData}
+        hydroData={hydroData}
+      />
+    );
     expect(screen.getByText('Curva del bed-load')).toBeInTheDocument();
     expect(screen.getByText('Profilo di concentrazione')).toBeInTheDocument();
     expect(screen.getByText('Carico totale')).toBeInTheDocument();
+    expect(screen.getByText('Impatto bilancio-sedimenti')).toBeInTheDocument();
   });
 });

--- a/src/components/Graphs.jsx
+++ b/src/components/Graphs.jsx
@@ -250,7 +250,13 @@ function Graphs({
         <EvolutionTable evolutionData={evolutionData} rangeVar={rangeVar} />
       </Widget>
     ),
-    sediments: <SedimentGraphs params={params} sedimentData={sedimentData} />,
+    sediments: (
+      <SedimentGraphs
+        params={params}
+        sedimentData={sedimentData}
+        hydroData={hydroData}
+      />
+    ),
     accumulation: (
       <DryAccumulation
         days={dryDays}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -109,7 +109,7 @@ export default function Sidebar({
                 }}
               >
                 <span className="w-4">{visibleCharts.sediments ? '✓' : ''}</span>
-                Sedimenti
+                Sedimenti e bilancio
               </button>
             </div>
           )}


### PR DESCRIPTION
## Summary
- add a grouped bar chart to visualise the effect of the hydrologic balance on sediment transport
- update sidebar menu text
- document the new chart in README and HELP
- adjust unit test for SedimentGraphs

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685947951058832f9f3d06779edba149