### PR TITLE
Add fullscreen toggle to widgets

### DIFF
--- a/src/Widget.css
+++ b/src/Widget.css
@@ -17,6 +17,11 @@
   line-height: 24px;
 }
 
+.widget-controls {
+  display: flex;
+  gap: 4px;
+}
+
 .widget {
   resize: both;
   overflow: auto;
@@ -30,4 +35,15 @@
   height: auto;
   overflow: hidden;
 }
+
+.widget.fullscreen {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 90vw;
+  height: 90vh;
+  z-index: 2000;
+}
+
 

--- a/src/Widget.jsx
+++ b/src/Widget.jsx
@@ -7,10 +7,12 @@ const Widget = forwardRef(function Widget(
   ref
 ) {
   const [collapsed, setCollapsed] = useState(false);
+  const [fullscreen, setFullscreen] = useState(false);
   return (
     <div
       id={id}
-      className={`chart-box widget${collapsed ? ' collapsed' : ''}`}
+      className={`chart-box widget${collapsed ? ' collapsed' : ''}${
+        fullscreen ? ' fullscreen' : ''}`}
       onDrop={(e) => {
         e.preventDefault();
         onDrop && onDrop(id);
@@ -26,9 +28,17 @@ const Widget = forwardRef(function Widget(
         onDragStart={() => onDragStart && onDragStart(id)}
       >
         <span>{title}</span>
-        <button onClick={() => setCollapsed((c) => !c)} aria-label="toggle widget">
-          {collapsed ? '+' : '-'}
-        </button>
+        <div className="widget-controls">
+          <button onClick={() => setCollapsed((c) => !c)} aria-label="toggle widget">
+            {collapsed ? '+' : '-'}
+          </button>
+          <button
+            onClick={() => setFullscreen((f) => !f)}
+            aria-label={fullscreen ? 'shrink widget' : 'expand widget'}
+          >
+            {fullscreen ? '🗗' : '🗖'}
+          </button>
+        </div>
       </div>
       {!collapsed && (
         <div className="widget-body" ref={ref}>

--- a/src/__tests__/AppComponent.test.jsx
+++ b/src/__tests__/AppComponent.test.jsx
@@ -22,6 +22,17 @@ describe('App component calculations', () => {
     expect(screen.getAllByLabelText('toggle widget')[0]).toBeInTheDocument();
   });
 
+  test('widget expand button toggles fullscreen', () => {
+    render(<App />);
+    const expand = screen.getAllByLabelText('expand widget')[0];
+    fireEvent.click(expand);
+    const fullscreenEl = expand.closest('.widget');
+    expect(fullscreenEl.classList.contains('fullscreen')).toBe(true);
+    const shrink = screen.getAllByLabelText('shrink widget')[0];
+    fireEvent.click(shrink);
+    expect(fullscreenEl.classList.contains('fullscreen')).toBe(false);
+  });
+
 
   test('line chart displays calculated values', () => {
     render(<App />);


### PR DESCRIPTION
## Summary
- add fullscreen button and state to `Widget`
- style expanded widgets
- test expand/shrink behavior

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685954393974832f894472a922c6e75e