### PR TITLE
Fix footer bar widget titles and visibility

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -263,12 +263,13 @@ export default function App() {
   const [appearanceOpen, setAppearanceOpen] = useState(false);
   const [minimizedWidgets, setMinimizedWidgets] = useState([]);
 
-  const toggleMinimized = (id, title) => {
-    setMinimizedWidgets((prev) =>
-      prev.some((w) => w.id === id)
-        ? prev.filter((w) => w.id !== id)
-        : [...prev, { id, title }]
-    );
+  const toggleMinimized = (id, collapsed, title) => {
+    setMinimizedWidgets((prev) => {
+      if (collapsed) {
+        return [...prev, { id, title }];
+      }
+      return prev.filter((w) => w.id !== id);
+    });
   };
 
   const toggleChart = (chart) =>

--- a/src/FooterBar.css
+++ b/src/FooterBar.css
@@ -14,8 +14,12 @@
 
 .footer-item {
   background: #fff;
-  padding: 2px 6px;
+  padding: 4px 10px;
   border: 1px solid #ccc;
   border-radius: 4px;
   cursor: pointer;
+  min-width: 100px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/FooterBar.jsx
+++ b/src/FooterBar.jsx
@@ -3,14 +3,13 @@ import PropTypes from 'prop-types';
 import './FooterBar.css';
 
 export default function FooterBar({ widgets, onRestore }) {
-  if (!widgets.length) return null;
   return (
     <div className="footer-bar">
       {widgets.map((w) => (
         <div
           key={w.id}
           className="footer-item"
-          onDoubleClick={() => onRestore(w.id)}
+          onDoubleClick={() => onRestore(w.id, false)}
         >
           {w.title}
         </div>


### PR DESCRIPTION
## Summary
- ensure footer bar is always rendered
- fix minimized widget titles and restore logic
- enlarge footer bar items so first word of title is visible

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595cf1c688832f997838b020f35e90