### PR TITLE
Fix widget imports

### DIFF
--- a/src/components/DryAccumulation.jsx
+++ b/src/components/DryAccumulation.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Widget from '../Widget';
+import Widget from './Widget';
 import {
   linearAccumulation,
   saturatingAccumulation,

--- a/src/components/HydroBalanceChart.jsx
+++ b/src/components/HydroBalanceChart.jsx
@@ -9,7 +9,7 @@ import {
   Legend,
   ResponsiveContainer
 } from 'recharts';
-import Widget from '../Widget';
+import Widget from './Widget';
 
 export default function HydroBalanceChart({
   data,

--- a/src/components/SedimentGraphs.jsx
+++ b/src/components/SedimentGraphs.jsx
@@ -12,7 +12,7 @@ import {
   LabelList,
   Legend
 } from 'recharts';
-import Widget from '../Widget';
+import Widget from './Widget';
 import {
   meyerPeterMuller,
   einsteinBedload,


### PR DESCRIPTION
## Summary
- fix relative path to Widget component in SedimentGraphs, HydroBalanceChart and DryAccumulation

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596fb5d93c832fa4bc4ba720108bdd