### PR TITLE
Enable image export for more charts and tables

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,7 +22,13 @@ import {
   importaParametri
 } from './utils';
 import { Help, Normativa } from './pages';
-import { Toast, ParameterControls, Graphs, Sidebar, FooterBar } from './components';
+import {
+  Toast,
+  ParameterControls,
+  Graphs,
+  Sidebar,
+  FooterBar
+} from './components';
 import { fetchRain, verifyApiKey } from './services';
 import { zoneDefaults } from './utils';
 import {
@@ -106,6 +112,8 @@ export default function App() {
   const pieRef = useRef(null);
   const lineRef = useRef(null);
   const evolutionRef = useRef(null);
+  const hydroRef = useRef(null);
+  const tableRef = useRef(null);
   const resultsRef = useRef(null);
   const fileInputRef = useRef(null);
 
@@ -269,8 +277,6 @@ export default function App() {
     setDragging(null);
   };
 
-
-
   const downloadCSV = () => {
     const rows = [
       ['Parametro', 'Valore'],
@@ -326,13 +332,26 @@ export default function App() {
   };
 
   const downloadImage = useCallback((ref, name) => {
-    const svg = ref.current?.querySelector('svg');
-    if (!svg) return;
-    const serializer = new XMLSerializer();
-    const svgString = serializer.serializeToString(svg);
+    const container = ref.current;
+    if (!container) return;
+    let svg = container.querySelector('svg');
+    let svgString;
+    if (svg) {
+      const serializer = new XMLSerializer();
+      svgString = serializer.serializeToString(svg);
+    } else {
+      const { width, height } = container.getBoundingClientRect();
+      const serializer = new XMLSerializer();
+      const html = serializer.serializeToString(container);
+      svgString =
+        `<svg xmlns='http://www.w3.org/2000/svg' width='${width}' height='${height}'>` +
+        `<foreignObject width='100%' height='100%'>` +
+        html +
+        '</foreignObject></svg>';
+    }
     const canvas = document.createElement('canvas');
-    canvas.width = svg.clientWidth;
-    canvas.height = svg.clientHeight;
+    canvas.width = container.clientWidth;
+    canvas.height = container.clientHeight;
     const ctx = canvas.getContext('2d');
     const img = new Image();
     img.onload = () => {
@@ -456,6 +475,8 @@ export default function App() {
           pieRef={pieRef}
           lineRef={lineRef}
           evolutionRef={evolutionRef}
+          hydroRef={hydroRef}
+          tableRef={tableRef}
         />
         <div className="rightPane flex-1 p-6 overflow-auto grid gap-4">
           {activePage === 'parameters' && (
@@ -517,6 +538,8 @@ export default function App() {
               pieRef={pieRef}
               lineRef={lineRef}
               evolutionRef={evolutionRef}
+              hydroRef={hydroRef}
+              tableRef={tableRef}
               resultsRef={resultsRef}
             />
           )}

--- a/src/components/EvolutionTable.jsx
+++ b/src/components/EvolutionTable.jsx
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import '../styles/EvolutionTable.css';
 
-export default function EvolutionTable({ evolutionData, rangeVar }) {
+const EvolutionTable = forwardRef(function EvolutionTable(
+  { evolutionData, rangeVar },
+  ref
+) {
   const header = rangeVar === 'v' ? 'v (m/s)' : 'Q (l/s)';
 
   return (
-    <table className="evolution-table">
+    <table className="evolution-table" ref={ref}>
       <thead>
         <tr>
           <th>{header}</th>
@@ -23,9 +26,11 @@ export default function EvolutionTable({ evolutionData, rangeVar }) {
       </tbody>
     </table>
   );
-}
+});
 
 EvolutionTable.propTypes = {
   evolutionData: PropTypes.arrayOf(PropTypes.object).isRequired,
   rangeVar: PropTypes.string.isRequired
 };
+
+export default EvolutionTable;

--- a/src/components/Graphs.jsx
+++ b/src/components/Graphs.jsx
@@ -59,6 +59,8 @@ function Graphs({
   pieRef,
   lineRef,
   evolutionRef,
+  hydroRef,
+  tableRef,
   resultsRef
 }) {
   const isMinimized = (id) => minimized?.some((w) => w.id === id);
@@ -212,6 +214,7 @@ function Graphs({
     ),
     hydro: !isMinimized('hydroBalance') && (
       <HydroBalanceChart
+        ref={hydroRef}
         data={hydroData}
         onCollapseToggle={toggleMinimized}
       />
@@ -274,7 +277,11 @@ function Graphs({
         onDrop={handleDrop}
         onCollapseToggle={toggleMinimized}
       >
-        <EvolutionTable evolutionData={evolutionData} rangeVar={rangeVar} />
+        <EvolutionTable
+          ref={tableRef}
+          evolutionData={evolutionData}
+          rangeVar={rangeVar}
+        />
       </Widget>
     ),
     sediments: (
@@ -337,6 +344,8 @@ Graphs.propTypes = {
   pieRef: PropTypes.object,
   lineRef: PropTypes.object,
   evolutionRef: PropTypes.object,
+  hydroRef: PropTypes.object,
+  tableRef: PropTypes.object,
   resultsRef: PropTypes.object
 };
 

--- a/src/components/HydroBalanceChart.jsx
+++ b/src/components/HydroBalanceChart.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import {
   LineChart,
@@ -11,17 +11,17 @@ import {
 } from 'recharts';
 import Widget from './Widget';
 
-export default function HydroBalanceChart({
-  data,
-  collapsed,
-  onCollapseToggle
-}) {
+const HydroBalanceChart = forwardRef(function HydroBalanceChart(
+  { data, collapsed, onCollapseToggle },
+  ref
+) {
   return (
     <Widget
       id="hydroBalance"
       title="Bilancio idrologico"
       collapsed={collapsed}
       onCollapseToggle={onCollapseToggle}
+      ref={ref}
     >
       <ResponsiveContainer width="100%" height={300}>
         <LineChart data={data}>
@@ -38,10 +38,12 @@ export default function HydroBalanceChart({
       </ResponsiveContainer>
     </Widget>
   );
-}
+});
 
 HydroBalanceChart.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
   collapsed: PropTypes.bool,
   onCollapseToggle: PropTypes.func
 };
+
+export default HydroBalanceChart;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -31,6 +31,8 @@ export default function Sidebar({
   pieRef,
   lineRef,
   evolutionRef,
+  hydroRef,
+  tableRef
 }) {
   return (
     <aside
@@ -45,7 +47,9 @@ export default function Sidebar({
       <nav className="menu-vertical flex flex-col space-y-2 mt-2">
         <button
           className="px-4 py-2 text-left hover:bg-gray-100 w-full"
-          onClick={() => setActivePage(activePage === 'parameters' ? 'graphs' : 'parameters')}
+          onClick={() =>
+            setActivePage(activePage === 'parameters' ? 'graphs' : 'parameters')
+          }
         >
           {activePage === 'parameters' ? 'Simulazione' : 'Parametri'}
         </button>
@@ -73,32 +77,57 @@ export default function Sidebar({
           </button>
           {appearanceOpen && (
             <div className="submenu ml-4 mt-1 space-y-1">
-              <button className="submenu-item w-full text-left flex items-center" onClick={() => toggleChart('radar')}>
+              <button
+                className="submenu-item w-full text-left flex items-center"
+                onClick={() => toggleChart('radar')}
+              >
                 <span className="w-4">{visibleCharts.radar ? '✓' : ''}</span>
                 Grafico radar
               </button>
-              <button className="submenu-item w-full text-left flex items-center" onClick={() => toggleChart('bar')}>
+              <button
+                className="submenu-item w-full text-left flex items-center"
+                onClick={() => toggleChart('bar')}
+              >
                 <span className="w-4">{visibleCharts.bar ? '✓' : ''}</span>
                 Grafico a barre
               </button>
-              <button className="submenu-item w-full text-left flex items-center" onClick={() => toggleChart('pie')}>
+              <button
+                className="submenu-item w-full text-left flex items-center"
+                onClick={() => toggleChart('pie')}
+              >
                 <span className="w-4">{visibleCharts.pie ? '✓' : ''}</span>
                 Grafico a torta
               </button>
-              <button className="submenu-item w-full text-left flex items-center" onClick={() => toggleChart('hydro')}>
+              <button
+                className="submenu-item w-full text-left flex items-center"
+                onClick={() => toggleChart('hydro')}
+              >
                 <span className="w-4">{visibleCharts.hydro ? '✓' : ''}</span>
                 Bilancio idrologico
               </button>
-              <button className="submenu-item w-full text-left flex items-center" onClick={() => toggleChart('line')}>
+              <button
+                className="submenu-item w-full text-left flex items-center"
+                onClick={() => toggleChart('line')}
+              >
                 <span className="w-4">{visibleCharts.line ? '✓' : ''}</span>
                 Grafico a linee
               </button>
-              <button className="submenu-item w-full text-left flex items-center" onClick={() => toggleChart('evolution')}>
-                <span className="w-4">{visibleCharts.evolution ? '✓' : ''}</span>
+              <button
+                className="submenu-item w-full text-left flex items-center"
+                onClick={() => toggleChart('evolution')}
+              >
+                <span className="w-4">
+                  {visibleCharts.evolution ? '✓' : ''}
+                </span>
                 Grafico evolutivo
               </button>
-              <button className="submenu-item w-full text-left flex items-center" onClick={() => toggleChart('evolutionTable')}>
-                <span className="w-4">{visibleCharts.evolutionTable ? '✓' : ''}</span>
+              <button
+                className="submenu-item w-full text-left flex items-center"
+                onClick={() => toggleChart('evolutionTable')}
+              >
+                <span className="w-4">
+                  {visibleCharts.evolutionTable ? '✓' : ''}
+                </span>
                 Tabella evolutiva
               </button>
               <button
@@ -108,7 +137,9 @@ export default function Sidebar({
                   toggleChart('accumulation');
                 }}
               >
-                <span className="w-4">{visibleCharts.sediments ? '✓' : ''}</span>
+                <span className="w-4">
+                  {visibleCharts.sediments ? '✓' : ''}
+                </span>
                 Sedimenti e bilancio
               </button>
             </div>
@@ -136,12 +167,32 @@ export default function Sidebar({
                 style={{ display: 'none' }}
                 onChange={importaJSON}
               />
-              <button onClick={() => fileInputRef.current.click()}>Importa JSON</button>
-              <button onClick={() => downloadImage(radarRef, 'radar.png')}>Salva radar</button>
-              <button onClick={() => downloadImage(barRef, 'barre.png')}>Salva barre</button>
-              <button onClick={() => downloadImage(pieRef, 'torta.png')}>Salva torta</button>
-              <button onClick={() => downloadImage(lineRef, 'linee.png')}>Salva linee</button>
-              <button onClick={() => downloadImage(evolutionRef, 'evoluzione.png')}>Salva evolutivo</button>
+              <button onClick={() => fileInputRef.current.click()}>
+                Importa JSON
+              </button>
+              <button onClick={() => downloadImage(radarRef, 'radar.png')}>
+                Salva radar
+              </button>
+              <button onClick={() => downloadImage(barRef, 'barre.png')}>
+                Salva barre
+              </button>
+              <button onClick={() => downloadImage(pieRef, 'torta.png')}>
+                Salva torta
+              </button>
+              <button onClick={() => downloadImage(lineRef, 'linee.png')}>
+                Salva linee
+              </button>
+              <button
+                onClick={() => downloadImage(evolutionRef, 'evoluzione.png')}
+              >
+                Salva evolutivo
+              </button>
+              <button onClick={() => downloadImage(hydroRef, 'bilancio.png')}>
+                Salva bilancio
+              </button>
+              <button onClick={() => downloadImage(tableRef, 'tabella.png')}>
+                Salva tabella
+              </button>
             </div>
           )}
         </div>
@@ -196,4 +247,6 @@ Sidebar.propTypes = {
   pieRef: PropTypes.object.isRequired,
   lineRef: PropTypes.object.isRequired,
   evolutionRef: PropTypes.object.isRequired,
+  hydroRef: PropTypes.object.isRequired,
+  tableRef: PropTypes.object.isRequired
 };


### PR DESCRIPTION
## Summary
- allow saving hydro balance chart and evolution table
- add export buttons for bilancio and tabella
- support capturing non-SVG elements in `downloadImage`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597c753a08832fbdbe3e75234dd788